### PR TITLE
initator members public

### DIFF
--- a/initiator.go
+++ b/initiator.go
@@ -8,11 +8,11 @@ import (
 )
 
 type Initiator interface {
-	oid() asn1.ObjectIdentifier
-	initSecContext() ([]byte, error)            // GSS_Init_sec_context
-	acceptSecContext(sc []byte) ([]byte, error) // GSS_Accept_sec_context
-	sum(bs []byte) []byte                       // GSS_getMIC
-	sessionKey() []byte                         // QueryContextAttributes(ctx, SECPKG_ATTR_SESSION_KEY, &out)
+	OID() asn1.ObjectIdentifier
+	InitSecContext() ([]byte, error)            // GSS_Init_sec_context
+	AcceptSecContext(sc []byte) ([]byte, error) // GSS_Accept_sec_context
+	Sum(bs []byte) []byte                       // GSS_getMIC
+	SessionKey() []byte                         // QueryContextAttributes(ctx, SECPKG_ATTR_SESSION_KEY, &out)
 }
 
 // NTLMInitiator implements session-setup through NTLMv2.
@@ -29,11 +29,11 @@ type NTLMInitiator struct {
 	seqNum uint32
 }
 
-func (i *NTLMInitiator) oid() asn1.ObjectIdentifier {
+func (i *NTLMInitiator) OID() asn1.ObjectIdentifier {
 	return spnego.NlmpOid
 }
 
-func (i *NTLMInitiator) initSecContext() ([]byte, error) {
+func (i *NTLMInitiator) InitSecContext() ([]byte, error) {
 	i.ntlm = &ntlm.Client{
 		User:        i.User,
 		Password:    i.Password,
@@ -49,7 +49,7 @@ func (i *NTLMInitiator) initSecContext() ([]byte, error) {
 	return nmsg, nil
 }
 
-func (i *NTLMInitiator) acceptSecContext(sc []byte) ([]byte, error) {
+func (i *NTLMInitiator) AcceptSecContext(sc []byte) ([]byte, error) {
 	amsg, err := i.ntlm.Authenticate(sc)
 	if err != nil {
 		return nil, err
@@ -57,12 +57,12 @@ func (i *NTLMInitiator) acceptSecContext(sc []byte) ([]byte, error) {
 	return amsg, nil
 }
 
-func (i *NTLMInitiator) sum(bs []byte) []byte {
+func (i *NTLMInitiator) Sum(bs []byte) []byte {
 	mic, _ := i.ntlm.Session().Sum(bs, i.seqNum)
 	return mic
 }
 
-func (i *NTLMInitiator) sessionKey() []byte {
+func (i *NTLMInitiator) SessionKey() []byte {
 	return i.ntlm.Session().SessionKey()
 }
 

--- a/spnego.go
+++ b/spnego.go
@@ -15,7 +15,7 @@ type spnegoClient struct {
 func newSpnegoClient(mechs []Initiator) *spnegoClient {
 	mechTypes := make([]asn1.ObjectIdentifier, len(mechs))
 	for i, mech := range mechs {
-		mechTypes[i] = mech.oid()
+		mechTypes[i] = mech.OID()
 	}
 	return &spnegoClient{
 		mechs:     mechs,
@@ -28,7 +28,7 @@ func (c *spnegoClient) oid() asn1.ObjectIdentifier {
 }
 
 func (c *spnegoClient) initSecContext() (negTokenInitBytes []byte, err error) {
-	mechToken, err := c.mechs[0].initSecContext()
+	mechToken, err := c.mechs[0].InitSecContext()
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func (c *spnegoClient) acceptSecContext(negTokenRespBytes []byte) (negTokenRespB
 		}
 	}
 
-	responseToken, err := c.selectedMech.acceptSecContext(negTokenResp.ResponseToken)
+	responseToken, err := c.selectedMech.AcceptSecContext(negTokenResp.ResponseToken)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (c *spnegoClient) acceptSecContext(negTokenRespBytes []byte) (negTokenRespB
 		return nil, err
 	}
 
-	mechListMIC := c.selectedMech.sum(ms)
+	mechListMIC := c.selectedMech.Sum(ms)
 
 	negTokenRespBytes1, err = spnego.EncodeNegTokenResp(1, nil, responseToken, mechListMIC)
 	if err != nil {
@@ -73,9 +73,9 @@ func (c *spnegoClient) acceptSecContext(negTokenRespBytes []byte) (negTokenRespB
 }
 
 func (c *spnegoClient) sum(bs []byte) []byte {
-	return c.selectedMech.sum(bs)
+	return c.selectedMech.Sum(bs)
 }
 
 func (c *spnegoClient) sessionKey() []byte {
-	return c.selectedMech.sessionKey()
+	return c.selectedMech.SessionKey()
 }


### PR DESCRIPTION
The members of the [Initiator interface](https://github.com/CloudSoda/go-smb2/blob/master/initiator.go#L10-L16) are private. That makes it impossible to plug in other initiators that might have additional capabilities.

This PR changes those to public, so that you can plug others ones in. It also changes the one implementation, `NTLMInitiator`, to use public methods so it implements the modified interface. Finally, it changes the one place (`spnego.go`) that references it to use the modified interface members.

This does not change the go-smb2 functionality at all, but does make it more pluggable.