### PR TITLE
Golint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,6 +30,11 @@ jobs:
     - run: |
         cp ./.github/client_conf.json ./
         go test -v -race ./...
+    - uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.52.2
+        skip-cache: true
+        args: --timeout=8m
   test_windows:
     strategy:
       matrix:
@@ -57,3 +62,9 @@ jobs:
     - run: |
         cp ./.github/client_conf.json ./
         go test -v -race ./...
+    - uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.52.2
+        skip-cache: true
+        args: --timeout=8m
+  

--- a/client.go
+++ b/client.go
@@ -161,7 +161,9 @@ func (c *Session) ListSharenames() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer fs.Umount()
+	defer func() {
+		_ = fs.Umount()
+	}()
 
 	fs = fs.WithContext(c.ctx)
 
@@ -376,7 +378,7 @@ func (fs *Share) OpenFile(name string, flag int, perm os.FileMode) (*File, error
 		return nil, &os.PathError{Op: "open", Path: name, Err: err}
 	}
 	if flag&os.O_APPEND != 0 {
-		f.seek(0, io.SeekEnd)
+		_, _ = f.seek(0, io.SeekEnd)
 	}
 	return f, nil
 }
@@ -645,7 +647,7 @@ func (fs *Share) Symlink(target, linkpath string) error {
 
 	_, err = f.ioctl(req)
 	if err != nil {
-		f.remove()
+		_ = f.remove()
 		f.close()
 
 		return &os.PathError{Op: "symlink", Path: f.name, Err: err}

--- a/conn.go
+++ b/conn.go
@@ -322,10 +322,12 @@ func (conn *conn) enableSession() {
 	atomic.StoreInt32(&conn._useSession, 1)
 }
 
+//nolint:unused // appears to be legacy, unsure, so leaving for now
 func (conn *conn) newTimer() *time.Timer {
 	return time.NewTimer(5 * time.Second)
 }
 
+//nolint:unused // appears to be legacy, unsure, so leaving for now
 func (conn *conn) sendRecv(cmd uint16, req Packet, ctx context.Context) (res []byte, err error) {
 	rr, err := conn.send(req, ctx)
 	if err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -27,20 +27,26 @@ func Example() {
 	if err != nil {
 		panic(err)
 	}
-	defer c.Logoff()
+	defer func() {
+		_ = c.Logoff()
+	}()
 
 	fs, err := c.Mount(`\\localhost\share`)
 	if err != nil {
 		panic(err)
 	}
-	defer fs.Umount()
+	defer func() {
+		_ = fs.Umount()
+	}()
 
 	f, err := fs.Create("hello.txt")
 	if err != nil {
 		panic(err)
 	}
-	defer fs.Remove("hello.txt")
-	defer f.Close()
+	defer func() {
+		f.Close()
+		_ = fs.Remove("hello.txt")
+	}()
 
 	_, err = f.Write([]byte("Hello world!"))
 	if err != nil {

--- a/initiator.go
+++ b/initiator.go
@@ -66,6 +66,7 @@ func (i *NTLMInitiator) SessionKey() []byte {
 	return i.ntlm.Session().SessionKey()
 }
 
+//nolint:unused // appears to be legacy, unsure, so leaving for now
 func (i *NTLMInitiator) infoMap() *ntlm.InfoMap {
 	return i.ntlm.Session().InfoMap()
 }

--- a/internal/crypto/ccm/ccm.go
+++ b/internal/crypto/ccm/ccm.go
@@ -19,9 +19,11 @@ type ccm struct {
 // NewCCMWithNonceAndTagSizes returns the given 128-bit, block cipher wrapped in Counter with CBC-MAC Mode, which accepts nonces of the given length.
 // the formatting of this function is defined in SP800-38C, Appendix A.
 // Each arguments have own valid range:
-//   nonceSize should be one of the {7, 8, 9, 10, 11, 12, 13}.
-//   tagSize should be one of the {4, 6, 8, 10, 12, 14, 16}.
-//   Otherwise, it panics.
+//
+//	nonceSize should be one of the {7, 8, 9, 10, 11, 12, 13}.
+//	tagSize should be one of the {4, 6, 8, 10, 12, 14, 16}.
+//	Otherwise, it panics.
+//
 // The maximum payload size is defined as 1<<uint((15-nonceSize)*8)-1.
 // If the given payload size exceeds the limit, it returns a error (Seal returns nil instead).
 // The payload size is defined as len(plaintext) on Seal, len(ciphertext)-tagSize on Open.
@@ -140,32 +142,32 @@ func (ccm *ccm) getTag(Ctr, data, plaintext []byte) []byte {
 	if len(data) > 0 {
 		B[0] |= 1 << 6 // Adata
 
-		ccm.mac.Write(B)
+		_, _ = ccm.mac.Write(B)
 
 		if len(data) < (1<<15 - 1<<7) {
 			putUvarint(B[:2], uint64(len(data)))
 
-			ccm.mac.Write(B[:2])
+			_, _ = ccm.mac.Write(B[:2])
 		} else if len(data) <= 1<<31-1 {
 			B[0] = 0xff
 			B[1] = 0xfe
 			putUvarint(B[2:6], uint64(len(data)))
 
-			ccm.mac.Write(B[:6])
+			_, _ = ccm.mac.Write(B[:6])
 		} else {
 			B[0] = 0xff
 			B[1] = 0xff
 			putUvarint(B[2:10], uint64(len(data)))
 
-			ccm.mac.Write(B[:10])
+			_, _ = ccm.mac.Write(B[:10])
 		}
-		ccm.mac.Write(data)
+		_, _ = ccm.mac.Write(data)
 		ccm.mac.PadZero()
 	} else {
-		ccm.mac.Write(B)
+		_, _ = ccm.mac.Write(B)
 	}
 
-	ccm.mac.Write(plaintext)
+	_, _ = ccm.mac.Write(plaintext)
 	ccm.mac.PadZero()
 
 	return ccm.mac.Sum(nil)

--- a/internal/crypto/cmac/cmac_test.go
+++ b/internal/crypto/cmac/cmac_test.go
@@ -78,19 +78,19 @@ func TestCMAC(t *testing.T) {
 		t.Error("fail")
 	}
 
-	h.Write(msg2)
+	_, _ = h.Write(msg2)
 
 	if !bytes.Equal(h.Sum(nil), sum2) {
 		t.Error("fail")
 	}
 
-	h.Write(msg3)
+	_, _ = h.Write(msg3)
 
 	if !bytes.Equal(h.Sum(nil), sum3) {
 		t.Error("fail")
 	}
 
-	h.Write(msg4)
+	_, _ = h.Write(msg4)
 
 	if !bytes.Equal(h.Sum(nil), sum4) {
 		t.Error("fail")

--- a/internal/msrpc/msrpc.go
+++ b/internal/msrpc/msrpc.go
@@ -68,11 +68,11 @@ func (r *Bind) Encode(b []byte) {
 	le.PutUint16(b[28:30], 0)        // ctx item[1] .context id
 	le.PutUint16(b[30:32], 1)        // ctx item[1] .num trans items
 
-	hex.Decode(b[32:48], SRVSVC_UUID)
+	_, _ = hex.Decode(b[32:48], SRVSVC_UUID)
 	le.PutUint16(b[48:50], SRVSVC_VERSION)
 	le.PutUint16(b[50:52], SRVSVC_VERSION_MINOR)
 
-	hex.Decode(b[52:68], NDR_UUID)
+	_, _ = hex.Decode(b[52:68], NDR_UUID)
 	le.PutUint32(b[68:72], NDR_VERSION)
 }
 

--- a/internal/ntlm/client.go
+++ b/internal/ntlm/client.go
@@ -23,7 +23,7 @@ type Client struct {
 	Workstation string // e.g "localhost", "HOME-PC"
 
 	TargetSPN       string           // SPN ::= "service/hostname[:port]"; e.g "cifs/remotehost:1020"
-	channelBindings *channelBindings // reserved for future implementation
+	channelBindings *channelBindings //nolint:unused // reserved for future implementation
 
 	nmsg    []byte
 	session *Session

--- a/internal/ntlm/ntlm.go
+++ b/internal/ntlm/ntlm.go
@@ -8,7 +8,7 @@ import (
 	"hash"
 	"hash/crc32"
 
-	"golang.org/x/crypto/md4"
+	"golang.org/x/crypto/md4" //nolint:staticcheck // md4 may be deprecated, but SMB still uses it
 )
 
 var zero [16]byte
@@ -78,12 +78,15 @@ const (
 	MsvAvChannelBindings
 )
 
+//nolint:unused
 type addr struct {
 	typ uint32
 	val []byte
 }
 
 // channelBindings represents gss_channel_bindings_struct
+//
+//nolint:unused
 type channelBindings struct {
 	InitiatorAddress addr
 	AcceptorAddress  addr
@@ -236,6 +239,7 @@ func (i *targetInfoEncoder) encode(dst []byte) {
 	le.PutUint16(dst[off:off+2], MsvAvEOL)
 	le.PutUint16(dst[off+2:off+4], 0)
 
+	//nolint:ineffassign // we know that this does nothing, it will be removed in a later cleanup
 	off += 4
 }
 

--- a/internal/ntlm/server.go
+++ b/internal/ntlm/server.go
@@ -97,6 +97,7 @@ func (s *Server) Challenge(nmsg []byte) (cmsg []byte, err error) {
 		le.PutUint16(cmsg[40:42], uint16(len))
 		le.PutUint16(cmsg[42:44], uint16(len))
 		le.PutUint32(cmsg[44:48], uint32(off))
+		//nolint:ineffassign // we know that this does nothing, it will be removed in a later cleanup
 		off += len
 	}
 

--- a/internal/smb2/fscc.go
+++ b/internal/smb2/fscc.go
@@ -142,10 +142,7 @@ func (c SymbolicLinkReparseDataBufferDecoder) PrintName(mc utf16le.MapChars) str
 type SrvRequestResumeKeyResponseDecoder []byte
 
 func (c SrvRequestResumeKeyResponseDecoder) IsInvalid() bool {
-	if len(c) < int(28+c.ContextLength()) {
-		return true
-	}
-	return false
+	return len(c) < int(28+c.ContextLength())
 }
 
 func (c SrvRequestResumeKeyResponseDecoder) ResumeKey() []byte {

--- a/session.go
+++ b/session.go
@@ -21,7 +21,7 @@ import (
 func sessionSetup(conn *conn, i Initiator, ctx context.Context) (*session, error) {
 	spnego := newSpnegoClient([]Initiator{i})
 
-	outputToken, err := spnego.initSecContext()
+	outputToken, err := spnego.InitSecContext()
 	if err != nil {
 		return nil, &InvalidResponseError{err.Error()}
 	}
@@ -105,7 +105,7 @@ func sessionSetup(conn *conn, i Initiator, ctx context.Context) (*session, error
 
 	}
 
-	outputToken, err = spnego.acceptSecContext(r.SecurityBuffer())
+	outputToken, err = spnego.AcceptSecContext(r.SecurityBuffer())
 	if err != nil {
 		return nil, &InvalidResponseError{err.Error()}
 	}
@@ -124,7 +124,7 @@ func sessionSetup(conn *conn, i Initiator, ctx context.Context) (*session, error
 	}
 
 	if s.sessionFlags&(SMB2_SESSION_FLAG_IS_GUEST|SMB2_SESSION_FLAG_IS_NULL) == 0 {
-		sessionKey := spnego.sessionKey()
+		sessionKey := spnego.SessionKey()
 
 		switch conn.dialect {
 		case SMB202, SMB210:

--- a/smb2_fs_test.go
+++ b/smb2_fs_test.go
@@ -1,3 +1,4 @@
+//go:build go1.16
 // +build go1.16
 
 package smb2_test
@@ -21,7 +22,9 @@ func TestDirFS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer fs.RemoveAll(testDir)
+	defer func() {
+		_ = fs.RemoveAll(testDir)
+	}()
 
 	err = fs.WriteFile(path.Join(testDir, "hello.txt"), []byte("hello world!"), 0666)
 	if err != nil {
@@ -39,7 +42,7 @@ func TestDirFS(t *testing.T) {
 	{
 		var entries []string
 
-		iofs.WalkDir(fs.DirFS(testDir), ".", func(path string, d iofs.DirEntry, err error) error {
+		_ = iofs.WalkDir(fs.DirFS(testDir), ".", func(path string, d iofs.DirEntry, err error) error {
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -57,7 +60,7 @@ func TestDirFS(t *testing.T) {
 	{
 		var entries []string
 
-		iofs.WalkDir(fs.DirFS(testDir), "hello", func(path string, d iofs.DirEntry, err error) error {
+		_ = iofs.WalkDir(fs.DirFS(testDir), "hello", func(path string, d iofs.DirEntry, err error) error {
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -83,7 +86,9 @@ func TestGlobFS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer fs.RemoveAll(testDir)
+	defer func() {
+		_ = fs.RemoveAll(testDir)
+	}()
 
 	err = fs.WriteFile(path.Join(testDir, "hello.txt"), []byte("hello world!"), 0666)
 	if err != nil {

--- a/spnego.go
+++ b/spnego.go
@@ -23,11 +23,11 @@ func newSpnegoClient(mechs []Initiator) *spnegoClient {
 	}
 }
 
-func (c *spnegoClient) oid() asn1.ObjectIdentifier {
+func (c *spnegoClient) OID() asn1.ObjectIdentifier {
 	return spnego.SpnegoOid
 }
 
-func (c *spnegoClient) initSecContext() (negTokenInitBytes []byte, err error) {
+func (c *spnegoClient) InitSecContext() (negTokenInitBytes []byte, err error) {
 	mechToken, err := c.mechs[0].InitSecContext()
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func (c *spnegoClient) initSecContext() (negTokenInitBytes []byte, err error) {
 	return negTokenInitBytes, nil
 }
 
-func (c *spnegoClient) acceptSecContext(negTokenRespBytes []byte) (negTokenRespBytes1 []byte, err error) {
+func (c *spnegoClient) AcceptSecContext(negTokenRespBytes []byte) (negTokenRespBytes1 []byte, err error) {
 	negTokenResp, err := spnego.DecodeNegTokenResp(negTokenRespBytes)
 	if err != nil {
 		return nil, err
@@ -72,10 +72,10 @@ func (c *spnegoClient) acceptSecContext(negTokenRespBytes []byte) (negTokenRespB
 	return negTokenRespBytes1, nil
 }
 
-func (c *spnegoClient) sum(bs []byte) []byte {
+func (c *spnegoClient) Sum(bs []byte) []byte {
 	return c.selectedMech.Sum(bs)
 }
 
-func (c *spnegoClient) sessionKey() []byte {
+func (c *spnegoClient) SessionKey() []byte {
 	return c.selectedMech.SessionKey()
 }


### PR DESCRIPTION
First commit adds golint action to the CI workflow.  Second commit cleans up all of the lint errors.

* where it complained about ignored return values, explicitly added `_ =`. This includes in `defer` statements
* where it complained about unused structs, vars, or member functions, added a `//nolint:unused`, so we can track it.
* where it complained about ineffective assignment, added a `//nolint:ineffassign`, so we can track it.

In all cases, we endeavoured not to change the logic at all, including leaving unused vars or funcs, or ineffective assignment. Instead, we added `//nolint` comments, so we can track them and it passes CI.

Any of these always can be removed later, probably should, but in their own dedicated small PRs.