### PR TITLE
Updated Dialer.Dial* methods to fix Mount() related bugs and improve usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,6 @@ import (
 )
 
 func main() {
-	conn, err := net.Dial("tcp", "SERVERNAME:445")
-	if err != nil {
-		panic(err)
-	}
-	defer conn.Close()
-
 	d := &smb2.Dialer{
 		Initiator: &smb2.NTLMInitiator{
 			User:     "USERNAME",
@@ -48,7 +42,7 @@ func main() {
 		},
 	}
 
-	s, err := d.Dial(conn)
+	s, err := d.Dial(context.Background(), "SERVERNAME:445")
 	if err != nil {
 		panic(err)
 	}
@@ -78,12 +72,6 @@ import (
 )
 
 func main() {
-	conn, err := net.Dial("tcp", "SERVERNAME:445")
-	if err != nil {
-		panic(err)
-	}
-	defer conn.Close()
-
 	d := &smb2.Dialer{
 		Initiator: &smb2.NTLMInitiator{
 			User:     "USERNAME",
@@ -91,7 +79,7 @@ func main() {
 		},
 	}
 
-	s, err := d.Dial(conn)
+	s, err := d.Dial(context.Background(), "SERVERNAME:445")
 	if err != nil {
 		panic(err)
 	}
@@ -144,12 +132,6 @@ import (
 )
 
 func main() {
-	conn, err := net.Dial("tcp", "SERVERNAME:445")
-	if err != nil {
-		panic(err)
-	}
-	defer conn.Close()
-
 	d := &smb2.Dialer{
 		Initiator: &smb2.NTLMInitiator{
 			User:     "USERNAME",
@@ -157,7 +139,7 @@ func main() {
 		},
 	}
 
-	s, err := d.Dial(conn)
+	s, err := d.Dial(context.Background(), "SERVERNAME:445")
 	if err != nil {
 		panic(err)
 	}
@@ -201,12 +183,6 @@ import (
 )
 
 func main() {
-	conn, err := net.Dial("tcp", "SERVERNAME:445")
-	if err != nil {
-		panic(err)
-	}
-	defer conn.Close()
-
 	d := &smb2.Dialer{
 		Initiator: &smb2.NTLMInitiator{
 			User:     "USERNAME",
@@ -214,7 +190,7 @@ func main() {
 		},
 	}
 
-	s, err := d.Dial(conn)
+	s, err := d.Dial(context.Background(), "SERVERNAME:445")
 	if err != nil {
 		panic(err)
 	}

--- a/client.go
+++ b/client.go
@@ -34,12 +34,15 @@ func (d *Dialer) Dial(tcpConn net.Conn) (*Session, error) {
 	return d.DialContext(context.Background(), tcpConn)
 }
 
-// DialContext performs negotiation and authentication using the provided context.
-// Note that returned session doesn't inherit context.
-// If you want to use the same context, call Session.WithContext manually.
-// This implementation doesn't support multi-session on the same TCP connection.
-// If you want to use another session, you need to prepare another TCP connection at first.
-func (d *Dialer) DialContext(ctx context.Context, tcpConn net.Conn) (*Session, error) {
+func (d *Dialer) Dial2(ctx context.Context, address string) (*Session, error) {
+	conn, err := net.Dial("tcp", address)
+	if err != nil {
+		return nil, fmt.Errorf("establishing TCP connection: %w", err)
+	}
+	return d.DialConn(ctx, conn, address)
+}
+
+func (d *Dialer) DialConn(ctx context.Context, tcpConn net.Conn, address string) (*Session, error) {
 	if ctx == nil {
 		panic("nil context")
 	}
@@ -64,7 +67,44 @@ func (d *Dialer) DialContext(ctx context.Context, tcpConn net.Conn) (*Session, e
 		return nil, err
 	}
 
-	return &Session{s: s, ctx: context.Background(), addr: tcpConn.RemoteAddr().String()}, nil
+	return &Session{s: s, ctx: context.Background(), addr: tcpConn.RemoteAddr().String(), host: address}, nil
+}
+
+func (d *Dialer) DialContext(ctx context.Context, tcpConn net.Conn) (*Session, error) {
+	return d.DialContextWithHostname(ctx, tcpConn, "")
+}
+
+// DialContext performs negotiation and authentication using the provided context.
+// Note that returned session doesn't inherit context.
+// If you want to use the same context, call Session.WithContext manually.
+// This implementation doesn't support multi-session on the same TCP connection.
+// If you want to use another session, you need to prepare another TCP connection at first.
+func (d *Dialer) DialContextWithHostname(ctx context.Context, tcpConn net.Conn, hostname string) (*Session, error) {
+	if ctx == nil {
+		panic("nil context")
+	}
+	if d.Initiator == nil {
+		return nil, &InternalError{"Initiator is empty"}
+	}
+
+	maxCreditBalance := d.MaxCreditBalance
+	if maxCreditBalance == 0 {
+		maxCreditBalance = clientMaxCreditBalance
+	}
+
+	a := openAccount(maxCreditBalance)
+
+	conn, err := d.Negotiator.negotiate(direct(tcpConn), a, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := sessionSetup(conn, d.Initiator, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Session{s: s, ctx: context.Background(), addr: tcpConn.RemoteAddr().String(), host: hostname}, nil
 }
 
 type mountOptions struct {
@@ -107,13 +147,14 @@ type Session struct {
 	s    *session
 	ctx  context.Context
 	addr string
+	host string
 }
 
 func (c *Session) WithContext(ctx context.Context) *Session {
 	if ctx == nil {
 		panic("nil context")
 	}
-	return &Session{s: c.s, ctx: ctx, addr: c.addr}
+	return &Session{s: c.s, ctx: ctx, addr: c.addr, host: c.host}
 }
 
 // Logoff invalidates the current SMB session.
@@ -129,7 +170,11 @@ func (c *Session) Mount(sharename string, opts ...MountOption) (*Share, error) {
 	sharename = normPath(sharename)
 
 	if !strings.ContainsRune(sharename, '\\') {
-		sharename = fmt.Sprintf(`\\%s\%s`, c.addr, sharename)
+		if c.host != "" {
+			sharename = fmt.Sprintf(`\\%s\%s`, c.host, sharename)
+		} else {
+			sharename = fmt.Sprintf(`\\%s\%s`, c.addr, sharename)
+		}
 	}
 
 	if err := validateMountPath(sharename); err != nil {
@@ -151,6 +196,9 @@ func (c *Session) Mount(sharename string, opts ...MountOption) (*Share, error) {
 
 func (c *Session) ListSharenames() ([]string, error) {
 	servername := c.addr
+	if c.host != "" {
+		servername = c.host
+	}
 
 	fs, err := c.Mount(fmt.Sprintf(`\\%s\IPC$`, servername))
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -36,7 +36,13 @@ func (d *Dialer) Dial(ctx context.Context, address string) (*Session, error) {
 	if err != nil {
 		return nil, fmt.Errorf("establishing TCP connection: %w", err)
 	}
-	return d.DialConn(ctx, conn, address)
+
+	s, err := d.DialConn(ctx, conn, address)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return s, nil
 }
 
 /*

--- a/conn.go
+++ b/conn.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/cloudsoda/go-smb2/internal/erref"
 	. "github.com/cloudsoda/go-smb2/internal/smb2"
@@ -320,11 +319,6 @@ func (conn *conn) useSession() bool {
 
 func (conn *conn) enableSession() {
 	atomic.StoreInt32(&conn._useSession, 1)
-}
-
-//nolint:unused // appears to be legacy, unsure, so leaving for now
-func (conn *conn) newTimer() *time.Timer {
-	return time.NewTimer(5 * time.Second)
 }
 
 //nolint:unused // appears to be legacy, unsure, so leaving for now

--- a/example_test.go
+++ b/example_test.go
@@ -1,20 +1,14 @@
 package smb2_test
 
 import (
+	"context"
 	"fmt"
 	"io"
-	"net"
 
 	"github.com/cloudsoda/go-smb2"
 )
 
 func Example() {
-	conn, err := net.Dial("tcp", "localhost:445")
-	if err != nil {
-		panic(err)
-	}
-	defer conn.Close()
-
 	d := &smb2.Dialer{
 		Initiator: &smb2.NTLMInitiator{
 			User:     "Guest",
@@ -23,7 +17,7 @@ func Example() {
 		},
 	}
 
-	c, err := d.Dial(conn)
+	c, err := d.Dial(context.Background(), "localhost:445")
 	if err != nil {
 		panic(err)
 	}

--- a/smb2_test.go
+++ b/smb2_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"reflect"
 	"sort"
@@ -86,12 +85,6 @@ func connect(f func()) {
 			goto NO_CONNECTION
 		}
 
-		conn, err := net.Dial(cfg.Transport.Type, fmt.Sprintf("%s:%d", cfg.Transport.Host, cfg.Transport.Port))
-		if err != nil {
-			panic(err)
-		}
-		defer conn.Close()
-
 		if cfg.Session.Type != "ntlm" {
 			panic("unsupported session type")
 		}
@@ -111,7 +104,7 @@ func connect(f func()) {
 			},
 		}
 
-		c, err := dialer.Dial(conn)
+		c, err := dialer.Dial(context.Background(), fmt.Sprintf("%s:%d", cfg.Transport.Host, cfg.Transport.Port))
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
The TREECONNECT command requires a share path (\\servername\sharename) as an
argument, but when calling Mount() users typically just pass in the share name.
When that happens, go-smb2 creates a share path using the IP address of the
tcpConn that was passed to it and the share name, but this sometimes creates
problems for servers that expect the original fully qualified domain name of
the server in the server name component of the share path.

To address this, this commit replaces the existing Dialer.Dial* methods with
versions that are harder to use incorrectly. The new methods also require an
address argument so when a full share path is not passed to Mount(), the
address value from Dial* will be used as the servername in the share path.