### PR TITLE
Improve compatibility with stricter SMB servers

### DIFF
--- a/client.go
+++ b/client.go
@@ -1658,6 +1658,11 @@ func (f *File) chmod(mode os.FileMode) error {
 		attrs |= FILE_ATTRIBUTE_READONLY
 	}
 
+	// If the file is not a directory, we have to set the normal attribute.
+	if attrs&FILE_ATTRIBUTE_DIRECTORY == 0 {
+		attrs |= FILE_ATTRIBUTE_NORMAL
+	}
+
 	info := &SetInfoRequest{
 		FileInfoClass:         FileBasicInformation,
 		AdditionalInformation: 0,

--- a/client.go
+++ b/client.go
@@ -523,9 +523,8 @@ func (fs *Share) remove(name string) error {
 		FileAttributes:       0,
 		ShareAccess:          FILE_SHARE_DELETE,
 		CreateDisposition:    FILE_OPEN,
-		// CreateOptions:        FILE_OPEN_REPARSE_POINT | FILE_DELETE_ON_CLOSE,
-		CreateOptions: FILE_OPEN_REPARSE_POINT,
-		Mapping:       fs.mapping,
+		CreateOptions:        FILE_OPEN_REPARSE_POINT,
+		Mapping:              fs.mapping,
 	}
 	// FILE_DELETE_ON_CLOSE doesn't work for reparse point, so use FileDispositionInformation instead
 

--- a/internal/smb2/fscc.go
+++ b/internal/smb2/fscc.go
@@ -392,7 +392,7 @@ type FileDispositionInformationEncoder struct {
 }
 
 func (c *FileDispositionInformationEncoder) Size() int {
-	return 4
+	return 1
 }
 
 func (c *FileDispositionInformationEncoder) Encode(p []byte) {


### PR DESCRIPTION
This PR brings the following changes:

* it sets the correct size on FileDispositionInformation, as the previous size was wrong and some stricter systems would return `STATUS_INFO_LENGTH_MISMATCH` (e.g. VAST DataStore)
* it ensures `chmod` sets the correct attributes for files, as some stricter systems do not set/unset the `READONLY` attribute if the `NORMAL` attribute is not also set for files (e.g. VAST DataStore)
* it makes the tests work with configurable share names (instead of the hardcoded `tmp` and `tmp2`)
* it makes the tests work on systems that don't return `IPC$` for `ListSharenames` (e.g. on Dell EMC Isilon)

I have tested the changes locally on VAST DataStore, Dell EMC Isilon, Samba 4.13.7 and 4.20.6, and Windows Server 2022 10.0.20348.