### PR TITLE
[33] Use go v1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/cloudsoda/go-smb2
 
-go 1.23
+go 1.22
 
 require (
-	github.com/cloudsoda/sddl v0.0.0-20250203211958-38b2ba66781c
+	github.com/cloudsoda/sddl v0.0.0-20250224203730-98f426808d10
 	github.com/geoffgarside/ber v1.1.0
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/stretchr/testify v1.8.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cloudsoda/sddl v0.0.0-20250203211958-38b2ba66781c h1:7ehKjpHDKPsyXXX655yNSP4cFijNAYMtWgywSb8bO7s=
-github.com/cloudsoda/sddl v0.0.0-20250203211958-38b2ba66781c/go.mod h1:xQSEAheX+AlO+KEijxcVd2jnU6oV1dLwZG2bE9FbYT4=
+github.com/cloudsoda/sddl v0.0.0-20250224203730-98f426808d10 h1:hMxARgejEcCh95teDL1wqZZtntwt0FHPc9P3//F1u5w=
+github.com/cloudsoda/sddl v0.0.0-20250224203730-98f426808d10/go.mod h1:uvR42Hb/t52HQd7x5/ZLzZEK8oihrFpgnodIJ1vte2E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
By getting the latest version of github.com/cloudsoda/sddl which now supports go version 1.22