### PR TITLE
Update sddl version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudsoda/go-smb2
 go 1.22
 
 require (
-	github.com/cloudsoda/sddl v0.0.0-20250224203730-98f426808d10
+	github.com/cloudsoda/sddl v0.0.0-20250224235906-926454e91efc
 	github.com/geoffgarside/ber v1.1.0
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/stretchr/testify v1.8.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/cloudsoda/sddl v0.0.0-20250224203730-98f426808d10 h1:hMxARgejEcCh95teDL1wqZZtntwt0FHPc9P3//F1u5w=
 github.com/cloudsoda/sddl v0.0.0-20250224203730-98f426808d10/go.mod h1:uvR42Hb/t52HQd7x5/ZLzZEK8oihrFpgnodIJ1vte2E=
+github.com/cloudsoda/sddl v0.0.0-20250224235906-926454e91efc h1:0xCWmFKBmarCqqqLeM7jFBSw/Or81UEElFqO8MY+GDs=
+github.com/cloudsoda/sddl v0.0.0-20250224235906-926454e91efc/go.mod h1:uvR42Hb/t52HQd7x5/ZLzZEK8oihrFpgnodIJ1vte2E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
although `sddl` specifies `go version 1.22.x` in `go.mod` it was still using a call that is specific to `v1.23`, latest `sddl` version has the fix