### PR TITLE
go fix ./... with go-1.26.1

### DIFF
--- a/client.go
+++ b/client.go
@@ -933,15 +933,11 @@ func (fs *Share) ReadFile(filename string) ([]byte, error) {
 	var size int
 
 	if size64 <= maxInt {
-		size = int(size64)
-
 		// If a file claims a small size, read at least 512 bytes.
 		// In particular, files in Linux's /proc claim size 0 but
 		// then do not work right if read in small pieces,
 		// so an initial read of 1 byte would not work correctly.
-		if size < 512 {
-			size = 512
-		}
+		size = max(int(size64), 512)
 	} else {
 		size = maxInt
 	}
@@ -1163,7 +1159,7 @@ func (fs *Share) createFile(name string, req *smb2.CreateRequest, followSymlinks
 }
 
 func (fs *Share) createFileRec(name string, req *smb2.CreateRequest) (f *File, err error) {
-	for i := 0; i < clientMaxSymlinkDepth; i++ {
+	for range clientMaxSymlinkDepth {
 		req.CreditCharge, _, err = fs.loanCredit(0)
 		defer func() {
 			if err != nil {
@@ -1369,10 +1365,7 @@ const winMaxPayloadSize = 1024 * 1024 // windows system don't accept more than 1
 const singleCreditMaxPayloadSize = 64 * 1024
 
 func (f *File) maxReadSize() int {
-	size := int(f.fs.maxReadSize)
-	if size > winMaxPayloadSize {
-		size = winMaxPayloadSize
-	}
+	size := min(int(f.fs.maxReadSize), winMaxPayloadSize)
 	if f.fs.conn.capabilities&smb2.SMB2_GLOBAL_CAP_LARGE_MTU == 0 {
 		if size > singleCreditMaxPayloadSize {
 			size = singleCreditMaxPayloadSize
@@ -1382,10 +1375,7 @@ func (f *File) maxReadSize() int {
 }
 
 func (f *File) maxWriteSize() int {
-	size := int(f.fs.maxWriteSize)
-	if size > winMaxPayloadSize {
-		size = winMaxPayloadSize
-	}
+	size := min(int(f.fs.maxWriteSize), winMaxPayloadSize)
 	if f.fs.conn.capabilities&smb2.SMB2_GLOBAL_CAP_LARGE_MTU == 0 {
 		if size > singleCreditMaxPayloadSize {
 			size = singleCreditMaxPayloadSize
@@ -1395,10 +1385,7 @@ func (f *File) maxWriteSize() int {
 }
 
 func (f *File) maxTransactSize() int {
-	size := int(f.fs.maxTransactSize)
-	if size > winMaxPayloadSize {
-		size = winMaxPayloadSize
-	}
+	size := min(int(f.fs.maxTransactSize), winMaxPayloadSize)
 	if f.fs.conn.capabilities&smb2.SMB2_GLOBAL_CAP_LARGE_MTU == 0 {
 		if size > singleCreditMaxPayloadSize {
 			size = singleCreditMaxPayloadSize
@@ -2127,10 +2114,7 @@ func (f *File) encodeSize(e smb2.Encoder) int {
 }
 
 func (f *File) ioctl(req *smb2.IoctlRequest) (output []byte, err error) {
-	payloadSize := f.encodeSize(req.Input) + int(req.OutputCount)
-	if payloadSize < int(req.MaxOutputResponse+req.MaxInputResponse) {
-		payloadSize = int(req.MaxOutputResponse + req.MaxInputResponse)
-	}
+	payloadSize := max(f.encodeSize(req.Input)+int(req.OutputCount), int(req.MaxOutputResponse+req.MaxInputResponse))
 
 	if f.maxTransactSize() < payloadSize {
 		return nil, &InternalError{fmt.Sprintf("payload size %d exceeds max transact size %d", payloadSize, f.maxTransactSize())}
@@ -2236,10 +2220,7 @@ func (f *File) readdir(pattern string) (fi []os.FileInfo, err error) {
 }
 
 func (f *File) queryInfo(req *smb2.QueryInfoRequest) (infoBytes []byte, err error) {
-	payloadSize := f.encodeSize(req.Input)
-	if payloadSize < int(req.OutputBufferLength) {
-		payloadSize = int(req.OutputBufferLength)
-	}
+	payloadSize := max(f.encodeSize(req.Input), int(req.OutputBufferLength))
 
 	if f.maxTransactSize() < payloadSize {
 		return nil, &InternalError{fmt.Sprintf("payload size %d exceeds max transact size %d", payloadSize, f.maxTransactSize())}
@@ -2420,6 +2401,6 @@ func (fs *FileStat) IsDir() bool {
 	return fs.Mode().IsDir()
 }
 
-func (fs *FileStat) Sys() interface{} {
+func (fs *FileStat) Sys() any {
 	return fs
 }

--- a/client_fs.go
+++ b/client_fs.go
@@ -1,5 +1,3 @@
-//go:build go1.16
-
 package smb2
 
 import (

--- a/credit.go
+++ b/credit.go
@@ -67,7 +67,7 @@ func (a *account) charge(granted, requested uint16) {
 
 	a.m.Unlock()
 
-	for i := uint16(0); i < granted; i++ {
+	for range granted {
 		select {
 		case a.balance <- struct{}{}:
 		default:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudsoda/go-smb2
 
-go 1.22
+go 1.26.1
 
 require (
 	github.com/cloudsoda/sddl v0.0.0-20250224235906-926454e91efc

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/cloudsoda/sddl v0.0.0-20250224203730-98f426808d10 h1:hMxARgejEcCh95teDL1wqZZtntwt0FHPc9P3//F1u5w=
-github.com/cloudsoda/sddl v0.0.0-20250224203730-98f426808d10/go.mod h1:uvR42Hb/t52HQd7x5/ZLzZEK8oihrFpgnodIJ1vte2E=
 github.com/cloudsoda/sddl v0.0.0-20250224235906-926454e91efc h1:0xCWmFKBmarCqqqLeM7jFBSw/Or81UEElFqO8MY+GDs=
 github.com/cloudsoda/sddl v0.0.0-20250224235906-926454e91efc/go.mod h1:uvR42Hb/t52HQd7x5/ZLzZEK8oihrFpgnodIJ1vte2E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/crypto/ccm/ccm.go
+++ b/internal/crypto/ccm/ccm.go
@@ -179,7 +179,7 @@ func maxUvarint(n int) uint64 {
 
 // put uint64 as big endian.
 func putUvarint(bs []byte, u uint64) {
-	for i := 0; i < len(bs); i++ {
+	for i := range bs {
 		bs[i] = byte(u >> uint(8*(len(bs)-1-i)))
 	}
 }

--- a/internal/crypto/ccm/util.go
+++ b/internal/crypto/ccm/util.go
@@ -43,11 +43,8 @@ func sliceForAppend(in []byte, n int) (head, tail []byte) {
 
 // defined in src/crypto/cipher/xor.go
 func xorBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
-	for i := 0; i < n; i++ {
+	n := min(len(b), len(a))
+	for i := range n {
 		dst[i] = a[i] ^ b[i]
 	}
 	return n

--- a/internal/msrpc/msrpc.go
+++ b/internal/msrpc/msrpc.go
@@ -291,7 +291,7 @@ func (c NetShareEnumAllResponseDecoder) IsIncomplete() bool {
 			return true
 		}
 
-		for i := 0; i < count; i++ {
+		for range count {
 			if len(c) < offset+12 {
 				return true
 			}
@@ -310,7 +310,7 @@ func (c NetShareEnumAllResponseDecoder) IsIncomplete() bool {
 			return true
 		}
 
-		for i := 0; i < count; i++ {
+		for range count {
 			{ // name
 				if len(c) < offset+12 {
 					return true
@@ -361,7 +361,7 @@ func (c NetShareEnumAllResponseDecoder) ShareNameList() []string {
 	switch level {
 	case 0:
 		offset := 48 + count*4 // name pointer
-		for i := 0; i < count; i++ {
+		for i := range count {
 			noff := int(le.Uint32(c[offset+4 : offset+8]))    // offset
 			nlen := int(le.Uint32(c[offset+8:offset+12])) * 2 // actual count
 
@@ -371,7 +371,7 @@ func (c NetShareEnumAllResponseDecoder) ShareNameList() []string {
 		}
 	case 1:
 		offset := 48 + count*12
-		for i := 0; i < count; i++ {
+		for i := range count {
 			{ // name
 				noff := int(le.Uint32(c[offset+4 : offset+8]))    // offset
 				nlen := int(le.Uint32(c[offset+8:offset+12])) * 2 // actual count

--- a/internal/smb2/dtyp.go
+++ b/internal/smb2/dtyp.go
@@ -90,7 +90,7 @@ func (sid *Sid) Size() int {
 func (sid *Sid) Encode(p []byte) {
 	p[0] = sid.Revision
 	p[1] = uint8(len(sid.SubAuthority))
-	for j := 0; j < 6; j++ {
+	for j := range 6 {
 		p[2+j] = byte(sid.IdentifierAuthority >> uint64(8*(6-j)))
 	}
 	off := 8
@@ -124,7 +124,7 @@ func (c SidDecoder) SubAuthorityCount() uint8 {
 
 func (c SidDecoder) IdentifierAuthority() uint64 {
 	var u uint64
-	for j := 0; j < 6; j++ {
+	for j := range 6 {
 		u += uint64(c[7-j]) << uint64(8*j)
 	}
 	return u
@@ -134,7 +134,7 @@ func (c SidDecoder) SubAuthority() []uint32 {
 	count := c.SubAuthorityCount()
 	as := make([]uint32, count)
 	off := 8
-	for i := uint8(0); i < count; i++ {
+	for i := range count {
 		as[i] = le.Uint32(c[off : off+4])
 		off += 4
 	}

--- a/smb2_fs_test.go
+++ b/smb2_fs_test.go
@@ -1,6 +1,3 @@
-//go:build go1.16
-// +build go1.16
-
 package smb2_test
 
 import (

--- a/smb2_test.go
+++ b/smb2_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -51,8 +52,8 @@ type treeConnConfig struct {
 type config struct {
 	MaxCreditBalance uint16          `json:"max_credit_balance"`
 	Transport        transportConfig `json:"transport"`
-	Conn             connConfig      `json:"conn,omitempty"`
-	Session          sessionConfig   `json:"session,omitempty"`
+	Conn             connConfig      `json:"conn"`
+	Session          sessionConfig   `json:"session"`
 	TreeConn         treeConnConfig  `json:"tree_conn"`
 }
 
@@ -741,13 +742,7 @@ func TestListSharenames(t *testing.T) {
 	}
 	sort.Strings(names)
 	for _, expected := range []string{fsName, rfsName} {
-		found := false
-		for _, name := range names {
-			if name == expected {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(names, expected)
 		if !found {
 			t.Errorf("couldn't find share name %s in %v", expected, names)
 		}


### PR DESCRIPTION
This is an upgrade to go-1.26.1 and a run of `go fix ./...` over this repo with a couple of small hand-edits:

The comment in `client.go:938` was placed strangely inside the `max()` builtin by `go fix` -- I moved it back out.

The `//go:build` lines in `client_fs.go` and `smb2_fs_test.go` are no longer relevant. I deleted them.
