### PR TITLE
Reuse ciphertext buffer on encrypt path, shaves an allocation

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -442,7 +442,11 @@ func (conn *conn) makeRequestResponse(req smb2.Packet, tc *treeConn, ctx context
 	if s != nil {
 		if _, ok := req.(*smb2.SessionSetupRequest); !ok {
 			if s.sessionFlags&smb2.SMB2_SESSION_FLAG_ENCRYPT_DATA != 0 || (tc != nil && tc.shareFlags&smb2.SMB2_SHAREFLAG_ENCRYPT_DATA != 0) {
-				pkt, err = s.encrypt(pkt)
+				needed := 52 + len(pkt) + 16
+				if cap(s.encryptBuf) < needed {
+					s.encryptBuf = make([]byte, needed)
+				}
+				pkt, err = s.encrypt(pkt, s.encryptBuf[:needed])
 				if err != nil {
 					return nil, &InternalError{err.Error()}
 				}

--- a/session.go
+++ b/session.go
@@ -272,6 +272,8 @@ type session struct {
 	encrypter cipher.AEAD
 	decrypter cipher.AEAD
 
+	encryptBuf []byte // reusable ciphertext buffer; safe because conn.m serializes access
+
 	// applicationKey []byte
 }
 
@@ -368,9 +370,9 @@ func (s *session) verify(pkt []byte) (ok bool) {
 	return bytes.Equal(signature, p.Signature())
 }
 
-func (s *session) encrypt(pkt []byte) ([]byte, error) {
-	c := make([]byte, 52+len(pkt)+16)
-
+// encrypt encrypts pkt into c. len(c) must equal 52+len(pkt)+16.
+// Returns the wire-ready packet (c re-sliced to exclude the trailing tag).
+func (s *session) encrypt(pkt, c []byte) ([]byte, error) {
 	t := smb2.TransformCodec(c)
 
 	t.SetProtocolId()


### PR DESCRIPTION
Store a `[]byte` buffer in the session struct to reuse across encrypted writes. This is safe because `conn.m` is held from encryption through `Write()` completion, serializing all access to the buffer.

Before: (see allocation count)

```
BenchmarkRoundTrip/Encrypted/1KB-10         	  204016	      4992 ns/op	 205.13 MB/s	    3737 B/op	       8 allocs/op
```

After:

```
BenchmarkRoundTrip/Encrypted/1KB-10         	  224992	      4882 ns/op	 209.77 MB/s	    3545 B/op	       7 allocs/op
```

(This benchmark simulates reads, so the allocation that is shaved away is the encrypted read request. It won't have much impact on throughput in the benchmark.)