### PR TITLE
Reuse encoding buffer

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -297,10 +297,11 @@ type conn struct {
 
 	account *account
 
-	rdone chan struct{}
-	wdone chan struct{}
-	write chan []byte
-	werr  chan error
+	rdone     chan struct{}
+	wdone     chan struct{}
+	write     chan []byte
+	werr      chan error
+	encodeBuf []byte // retained request encoding buffer; reused under conn.m
 
 	m sync.Mutex
 
@@ -435,7 +436,11 @@ func (conn *conn) makeRequestResponse(req smb2.Packet, tc *treeConn, ctx context
 		}
 	}
 
-	pkt := make([]byte, req.Size())
+	needed := req.Size()
+	if cap(conn.encodeBuf) < needed {
+		conn.encodeBuf = make([]byte, needed)
+	}
+	pkt := conn.encodeBuf[:needed]
 
 	req.Encode(pkt)
 

--- a/conn.go
+++ b/conn.go
@@ -441,6 +441,7 @@ func (conn *conn) makeRequestResponse(req smb2.Packet, tc *treeConn, ctx context
 		conn.encodeBuf = make([]byte, needed)
 	}
 	pkt := conn.encodeBuf[:needed]
+	clear(pkt)
 
 	req.Encode(pkt)
 
@@ -451,6 +452,7 @@ func (conn *conn) makeRequestResponse(req smb2.Packet, tc *treeConn, ctx context
 				if cap(s.encryptBuf) < needed {
 					s.encryptBuf = make([]byte, needed)
 				}
+				clear(s.encryptBuf[:needed])
 				pkt, err = s.encrypt(pkt, s.encryptBuf[:needed])
 				if err != nil {
 					return nil, &InternalError{err.Error()}


### PR DESCRIPTION
Reuse request encoding buffer across sends
conn.encodeBuf is retained to encode outgoing request packets.
conn.m is held for the entire write sequence so serialized
access is guaranteed.

This shaves an allocation.

Before:
```
BenchmarkRoundTrip/Plain/1KB-10         	  329035	      3706 ns/op	 276.34 MB/s	    1627 B/op	       6 allocs/op
BenchmarkRoundTrip/Plain/64KB-10        	  128247	      9145 ns/op	7166.00 MB/s	   74212 B/op	       6 allocs/op
BenchmarkRoundTrip/Plain/1MB-10         	   22280	     53276 ns/op	19682.07 MB/s	 1057258 B/op	       6 allocs/op
BenchmarkRoundTrip/Encrypted/1KB-10     	  241368	      5028 ns/op	 203.67 MB/s	    3554 B/op	       7 allocs/op
BenchmarkRoundTrip/Encrypted/64KB-10    	   39223	     30939 ns/op	2118.22 MB/s	  164387 B/op	       7 allocs/op
BenchmarkRoundTrip/Encrypted/1MB-10     	    3859	    306180 ns/op	3424.71 MB/s	 2377340 B/op	       7 allocs/op
```

After:

```
BenchmarkRoundTrip/Plain/1KB-10         	  286184	      3561 ns/op	 287.58 MB/s	    1500 B/op	       5 allocs/op
BenchmarkRoundTrip/Plain/64KB-10        	  129012	      9022 ns/op	7264.18 MB/s	   74084 B/op	       5 allocs/op
BenchmarkRoundTrip/Plain/1MB-10         	   22854	     52175 ns/op	20097.33 MB/s	 1057221 B/op	       5 allocs/op
BenchmarkRoundTrip/Encrypted/1KB-10     	  240336	      4948 ns/op	 206.95 MB/s	    3426 B/op	       6 allocs/op
BenchmarkRoundTrip/Encrypted/64KB-10    	   39441	     30362 ns/op	2158.48 MB/s	  164319 B/op	       6 allocs/op
BenchmarkRoundTrip/Encrypted/1MB-10     	    3963	    307307 ns/op	3412.14 MB/s	 2376662 B/op	       6 allocs/op
```
