### PR TITLE
Move ctx to first position in internal func signatures

### DIFF
--- a/client.go
+++ b/client.go
@@ -97,12 +97,12 @@ func (d *Dialer) DialConn(ctx context.Context, tcpConn net.Conn, address string)
 
 	a := openAccount(maxCreditBalance)
 
-	conn, err := d.Negotiator.negotiate(direct(tcpConn), a, ctx)
+	conn, err := d.Negotiator.negotiate(ctx, direct(tcpConn), a)
 	if err != nil {
 		return nil, err
 	}
 
-	s, err := sessionSetup(conn, d.Initiator, ctx)
+	s, err := sessionSetup(ctx, conn, d.Initiator)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func (c *Session) Mount(sharename string, opts ...MountOption) (*Share, error) {
 		opt(&options)
 	}
 
-	tc, err := treeConnect(c.s, sharename, 0, options.mapping, c.ctx)
+	tc, err := treeConnect(c.ctx, c.s, sharename, 0, options.mapping)
 	if err != nil {
 		return nil, err
 	}
@@ -1227,7 +1227,7 @@ func evalSymlinkError(name string, errData []byte, mc utf16le.MapChars) (string,
 }
 
 func (fs *Share) sendRecv(cmd uint16, req smb2.Packet) (res []byte, err error) {
-	rr, err := fs.send(req, fs.ctx)
+	rr, err := fs.send(fs.ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -1241,7 +1241,7 @@ func (fs *Share) sendRecv(cmd uint16, req smb2.Packet) (res []byte, err error) {
 }
 
 func (fs *Share) loanCredit(payloadSize int) (creditCharge uint16, grantedPayloadSize int, err error) {
-	return fs.session.conn.loanCredit(payloadSize, fs.ctx)
+	return fs.session.conn.loanCredit(fs.ctx, payloadSize)
 }
 
 type File struct {

--- a/conn.go
+++ b/conn.go
@@ -86,7 +86,7 @@ func (n *Negotiator) makeRequest() (*smb2.NegotiateRequest, error) {
 	return req, nil
 }
 
-func (n *Negotiator) negotiate(t transport, a *account, ctx context.Context) (*conn, error) {
+func (n *Negotiator) negotiate(ctx context.Context, t transport, a *account) (*conn, error) {
 	conn := &conn{
 		t:                   t,
 		outstandingRequests: newOutstandingRequests(),
@@ -108,7 +108,7 @@ retry:
 
 	req.CreditCharge = 1
 
-	rr, err := conn.send(req, ctx)
+	rr, err := conn.send(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -323,8 +323,8 @@ func (conn *conn) enableSession() {
 }
 
 //lint:ignore U1000 appears to be legacy, unsure, so leaving for now
-func (conn *conn) sendRecv(cmd uint16, req smb2.Packet, ctx context.Context) (res []byte, err error) {
-	rr, err := conn.send(req, ctx)
+func (conn *conn) sendRecv(ctx context.Context, cmd uint16, req smb2.Packet) (res []byte, err error) {
+	rr, err := conn.send(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -337,14 +337,14 @@ func (conn *conn) sendRecv(cmd uint16, req smb2.Packet, ctx context.Context) (re
 	return accept(cmd, pkt)
 }
 
-func (conn *conn) loanCredit(payloadSize int, ctx context.Context) (creditCharge uint16, grantedPayloadSize int, err error) {
+func (conn *conn) loanCredit(ctx context.Context, payloadSize int) (creditCharge uint16, grantedPayloadSize int, err error) {
 	if conn.capabilities&smb2.SMB2_GLOBAL_CAP_LARGE_MTU == 0 {
 		creditCharge = 1
 	} else {
 		creditCharge = uint16((payloadSize-1)/(64*1024) + 1)
 	}
 
-	creditCharge, isComplete, err := conn.account.loan(creditCharge, ctx)
+	creditCharge, isComplete, err := conn.account.loan(ctx, creditCharge)
 	if err != nil {
 		return creditCharge, 0, err
 	}
@@ -359,11 +359,11 @@ func (conn *conn) chargeCredit(creditCharge uint16) {
 	conn.account.charge(creditCharge, creditCharge)
 }
 
-func (conn *conn) send(req smb2.Packet, ctx context.Context) (rr *requestResponse, err error) {
-	return conn.sendWith(req, nil, ctx)
+func (conn *conn) send(ctx context.Context, req smb2.Packet) (rr *requestResponse, err error) {
+	return conn.sendWith(ctx, req, nil)
 }
 
-func (conn *conn) sendWith(req smb2.Packet, tc *treeConn, ctx context.Context) (rr *requestResponse, err error) {
+func (conn *conn) sendWith(ctx context.Context, req smb2.Packet, tc *treeConn) (rr *requestResponse, err error) {
 	conn.m.Lock()
 	defer conn.m.Unlock()
 
@@ -378,7 +378,7 @@ func (conn *conn) sendWith(req smb2.Packet, tc *treeConn, ctx context.Context) (
 		// do nothing
 	}
 
-	rr, err = conn.makeRequestResponse(req, tc, ctx)
+	rr, err = conn.makeRequestResponse(ctx, req, tc)
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +406,7 @@ func (conn *conn) sendWith(req smb2.Packet, tc *treeConn, ctx context.Context) (
 	return rr, nil
 }
 
-func (conn *conn) makeRequestResponse(req smb2.Packet, tc *treeConn, ctx context.Context) (rr *requestResponse, err error) {
+func (conn *conn) makeRequestResponse(ctx context.Context, req smb2.Packet, tc *treeConn) (rr *requestResponse, err error) {
 	hdr := req.Header()
 
 	var msgId uint64

--- a/conn_bench_test.go
+++ b/conn_bench_test.go
@@ -188,7 +188,7 @@ func BenchmarkRoundTrip(b *testing.B) {
 					MinimumCount: 1,
 				}
 				req.CreditCharge = 1
-				rr, err := c.send(req, ctx)
+				rr, err := c.send(ctx, req)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -250,7 +250,7 @@ func BenchmarkRoundTrip(b *testing.B) {
 					MinimumCount: 1,
 				}
 				req.CreditCharge = 1
-				rr, err := c.send(req, ctx)
+				rr, err := c.send(ctx, req)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/credit.go
+++ b/credit.go
@@ -25,7 +25,7 @@ func (a *account) initRequest() uint16 {
 	return uint16(cap(a.balance) - len(a.balance))
 }
 
-func (a *account) loan(creditCharge uint16, ctx context.Context) (uint16, bool, error) {
+func (a *account) loan(ctx context.Context, creditCharge uint16) (uint16, bool, error) {
 	select {
 	case <-a.balance:
 	case <-ctx.Done():

--- a/session.go
+++ b/session.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cloudsoda/go-smb2/internal/smb2"
 )
 
-func sessionSetup(conn *conn, i Initiator, ctx context.Context) (*session, error) {
+func sessionSetup(ctx context.Context, conn *conn, i Initiator) (*session, error) {
 	spnego := newSpnegoClient([]Initiator{i})
 
 	outputToken, err := spnego.InitSecContext()
@@ -43,7 +43,7 @@ func sessionSetup(conn *conn, i Initiator, ctx context.Context) (*session, error
 	req.CreditCharge = 1
 	req.CreditRequestResponse = conn.account.initRequest()
 
-	rr, err := conn.send(req, ctx)
+	rr, err := conn.send(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func sessionSetup(conn *conn, i Initiator, ctx context.Context) (*session, error
 
 		req.CreditRequestResponse = 0
 
-		rr, err = s.send(req, ctx)
+		rr, err = s.send(ctx, req)
 		if err != nil {
 			return nil, err
 		}
@@ -282,7 +282,7 @@ func (s *session) logoff(ctx context.Context) error {
 
 	req.CreditCharge = 1
 
-	_, err := s.sendRecv(smb2.SMB2_LOGOFF, req, ctx)
+	_, err := s.sendRecv(ctx, smb2.SMB2_LOGOFF, req)
 	if err != nil {
 		return err
 	}
@@ -298,7 +298,7 @@ func (s *session) echo(ctx context.Context) error {
 
 	req.CreditCharge = 1
 
-	res, err := s.sendRecv(smb2.SMB2_ECHO, req, ctx)
+	res, err := s.sendRecv(ctx, smb2.SMB2_ECHO, req)
 	if err != nil {
 		return err
 	}
@@ -311,8 +311,8 @@ func (s *session) echo(ctx context.Context) error {
 	return nil
 }
 
-func (s *session) sendRecv(cmd uint16, req smb2.Packet, ctx context.Context) (res []byte, err error) {
-	rr, err := s.send(req, ctx)
+func (s *session) sendRecv(ctx context.Context, cmd uint16, req smb2.Packet) (res []byte, err error) {
+	rr, err := s.send(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/tree_conn.go
+++ b/tree_conn.go
@@ -19,7 +19,7 @@ type treeConn struct {
 	// maximalAccess uint32
 }
 
-func treeConnect(s *session, path string, flags uint16, mc utf16le.MapChars, ctx context.Context) (*treeConn, error) {
+func treeConnect(ctx context.Context, s *session, path string, flags uint16, mc utf16le.MapChars) (*treeConn, error) {
 	req := &smb2.TreeConnectRequest{
 		Flags:   flags,
 		Path:    path,
@@ -28,7 +28,7 @@ func treeConnect(s *session, path string, flags uint16, mc utf16le.MapChars, ctx
 
 	req.CreditCharge = 1
 
-	rr, err := s.send(req, ctx)
+	rr, err := s.send(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (tc *treeConn) disconnect(ctx context.Context) error {
 
 	req.CreditCharge = 1
 
-	res, err := tc.sendRecv(smb2.SMB2_TREE_DISCONNECT, req, ctx)
+	res, err := tc.sendRecv(ctx, smb2.SMB2_TREE_DISCONNECT, req)
 	if err != nil {
 		return err
 	}
@@ -79,8 +79,8 @@ func (tc *treeConn) disconnect(ctx context.Context) error {
 	return nil
 }
 
-func (tc *treeConn) sendRecv(cmd uint16, req smb2.Packet, ctx context.Context) (res []byte, err error) {
-	rr, err := tc.send(req, ctx)
+func (tc *treeConn) sendRecv(ctx context.Context, cmd uint16, req smb2.Packet) (res []byte, err error) {
+	rr, err := tc.send(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -93,8 +93,8 @@ func (tc *treeConn) sendRecv(cmd uint16, req smb2.Packet, ctx context.Context) (
 	return accept(cmd, pkt)
 }
 
-func (tc *treeConn) send(req smb2.Packet, ctx context.Context) (rr *requestResponse, err error) {
-	return tc.sendWith(req, tc, ctx)
+func (tc *treeConn) send(ctx context.Context, req smb2.Packet) (rr *requestResponse, err error) {
+	return tc.sendWith(ctx, req, tc)
 }
 
 func (tc *treeConn) recv(rr *requestResponse) (pkt []byte, err error) {


### PR DESCRIPTION
"ctx context.Context" is by convention in Go the first parameter in a parameter list. This commit rearranges the go-smb2 internal functions requiring a context to take ctx as their first parameter.