### PR TITLE
Remove treeConnTables

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -768,16 +768,6 @@ func (conn *conn) runReceiver() {
 
 					continue
 				}
-
-				if tc, ok := s.treeConnTables[p.TreeId()]; ok {
-					if tc.treeId != p.TreeId() {
-						conn.freePoolBuf(rb)
-
-						logger.Println("skip:", &InvalidResponseError{"unknown tree id"})
-
-						continue
-					}
-				}
 			}
 		}
 

--- a/conn_bench_test.go
+++ b/conn_bench_test.go
@@ -198,9 +198,8 @@ func BenchmarkReadAt(b *testing.B) {
 			defer cleanup()
 
 			c.session.Store(&session{
-				conn:           c,
-				treeConnTables: make(map[uint32]*treeConn),
-				sessionFlags:   smb2.SMB2_SESSION_FLAG_IS_GUEST,
+				conn:         c,
+				sessionFlags: smb2.SMB2_SESSION_FLAG_IS_GUEST,
 			})
 
 			responseData := make([]byte, sz.n)
@@ -241,12 +240,11 @@ func BenchmarkReadAt(b *testing.B) {
 			}
 
 			c.session.Store(&session{
-				conn:           c,
-				treeConnTables: make(map[uint32]*treeConn),
-				sessionFlags:   smb2.SMB2_SESSION_FLAG_ENCRYPT_DATA,
-				sessionId:      0xdeadbeef,
-				encrypter:      newGCM(keyC2S),
-				decrypter:      newGCM(keyS2C),
+				conn:         c,
+				sessionFlags: smb2.SMB2_SESSION_FLAG_ENCRYPT_DATA,
+				sessionId:    0xdeadbeef,
+				encrypter:    newGCM(keyC2S),
+				decrypter:    newGCM(keyS2C),
 			})
 			c.useSession.Store(true)
 
@@ -342,12 +340,11 @@ func BenchmarkRoundTrip(b *testing.B) {
 			}
 
 			c.session.Store(&session{
-				conn:           c,
-				treeConnTables: make(map[uint32]*treeConn),
-				sessionFlags:   smb2.SMB2_SESSION_FLAG_ENCRYPT_DATA,
-				sessionId:      0xdeadbeef,
-				encrypter:      newGCM(keyC2S),
-				decrypter:      newGCM(keyS2C),
+				conn:         c,
+				sessionFlags: smb2.SMB2_SESSION_FLAG_ENCRYPT_DATA,
+				sessionId:    0xdeadbeef,
+				encrypter:    newGCM(keyC2S),
+				decrypter:    newGCM(keyS2C),
 			})
 			c.useSession.Store(true)
 

--- a/session.go
+++ b/session.go
@@ -81,10 +81,9 @@ func sessionSetup(ctx context.Context, conn *conn, i Initiator) (*session, error
 	}
 
 	s := &session{
-		conn:           conn,
-		treeConnTables: make(map[uint32]*treeConn),
-		sessionFlags:   sessionFlags,
-		sessionId:      p.SessionId(),
+		conn:         conn,
+		sessionFlags: sessionFlags,
+		sessionId:    p.SessionId(),
 	}
 
 	switch conn.dialect {
@@ -262,7 +261,6 @@ func sessionSetup(ctx context.Context, conn *conn, i Initiator) (*session, error
 
 type session struct {
 	*conn
-	treeConnTables            map[uint32]*treeConn
 	sessionFlags              uint16
 	sessionId                 uint64
 	preauthIntegrityHashValue [64]byte


### PR DESCRIPTION
This is dead code. Likely intended to keep track of tree connections. Removing it now.