### PR TITLE
Fix for IBM iSeries session

### DIFF
--- a/conn_bench_test.go
+++ b/conn_bench_test.go
@@ -55,13 +55,14 @@ func newGCM(key []byte) cipher.AEAD {
 }
 
 // fakeServer reads SMB2 requests from t and writes back a fixed ReadResponse
-// with the matching MessageId. It reuses all buffers to avoid polluting the
-// benchmark with server-side allocations.
-func fakeServer(t transport, responseData []byte) {
+// with the matching MessageId and the given sessionId. It reuses all buffers
+// to avoid polluting the benchmark with server-side allocations.
+func fakeServer(t transport, responseData []byte, sessionId uint64) {
 	// Pre-build response template.
 	resp := &smb2.ReadResponse{
 		PacketHeader: smb2.PacketHeader{
-			Flags: smb2.SMB2_FLAGS_SERVER_TO_REDIR,
+			Flags:     smb2.SMB2_FLAGS_SERVER_TO_REDIR,
+			SessionId: sessionId,
 		},
 		Data: responseData,
 	}
@@ -203,7 +204,7 @@ func BenchmarkReadAt(b *testing.B) {
 			})
 
 			responseData := make([]byte, sz.n)
-			go fakeServer(direct(serverConn), responseData)
+			go fakeServer(direct(serverConn), responseData, 0)
 
 			f := newBenchFile(c)
 			buf := make([]byte, sz.n)
@@ -293,7 +294,7 @@ func BenchmarkRoundTrip(b *testing.B) {
 			defer cleanup()
 
 			responseData := make([]byte, sz.n)
-			go fakeServer(direct(serverConn), responseData)
+			go fakeServer(direct(serverConn), responseData, 0)
 
 			fid := &smb2.FileId{}
 			ctx := context.Background()

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,67 @@
+package smb2
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/cloudsoda/go-smb2/internal/smb2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionRecv(t *testing.T) {
+	require := require.New(t)
+
+	// helper sends one request through c and returns the result of s.recv.
+	roundTrip := func(t *testing.T, c *conn, s *session) error {
+		t.Helper()
+		var req smb2.ReadRequest
+		req.CreditCharge = 1
+		rr, err := c.send(context.Background(), &req)
+		require.NoError(err)
+		_, err = s.recv(rr)
+		return err
+	}
+
+	t.Run("AdoptsSessionId", func(t *testing.T) {
+		clientConn, serverConn := net.Pipe()
+		c, cleanup := newBenchConn(clientConn)
+		defer cleanup()
+
+		const serverSessionId uint64 = 0x1234
+		go fakeServer(direct(serverConn), nil, serverSessionId)
+
+		s := &session{conn: c, sessionId: 0}
+
+		require.NoError(roundTrip(t, c, s))
+		require.Equal(serverSessionId, s.sessionId)
+	})
+
+	t.Run("MatchingSessionId", func(t *testing.T) {
+		clientConn, serverConn := net.Pipe()
+		c, cleanup := newBenchConn(clientConn)
+		defer cleanup()
+
+		const id uint64 = 0xCAFE
+		go fakeServer(direct(serverConn), nil, id)
+
+		s := &session{conn: c, sessionId: id}
+
+		require.NoError(roundTrip(t, c, s))
+		require.Equal(id, s.sessionId)
+	})
+
+	t.Run("RejectsSessionIdMismatch", func(t *testing.T) {
+		clientConn, serverConn := net.Pipe()
+		c, cleanup := newBenchConn(clientConn)
+		defer cleanup()
+
+		go fakeServer(direct(serverConn), nil, 0xBBBB)
+
+		s := &session{conn: c, sessionId: 0xAAAA}
+
+		err := roundTrip(t, c, s)
+		require.Error(err)
+		require.IsType(&InvalidResponseError{}, err)
+	})
+}

--- a/session.go
+++ b/session.go
@@ -328,7 +328,13 @@ func (s *session) recv(rr *requestResponse) (pkt []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if sessionId := smb2.PacketCodec(pkt).SessionId(); sessionId != s.sessionId {
+	// IBM i NetServer (iSeries/AS400) assigns the session ID only in the
+	// STATUS_MORE_PROCESSING_REQUIRED response, while the client's sessionId
+	// is still 0. Adopt the server's session ID in that case.
+	sessionId := smb2.PacketCodec(pkt).SessionId()
+	if s.sessionId == 0 {
+		s.sessionId = sessionId
+	} else if sessionId != s.sessionId {
 		return nil, &InvalidResponseError{fmt.Sprintf("expected session id: %v, got %v", s.sessionId, sessionId)}
 	}
 	return pkt, err


### PR DESCRIPTION
I tried to use rclone that uses your library to connect to an IBM iSeries, but i got the error:

```
2024/06/07 16:51:43 DEBUG : rclone: Version "v1.66.0" starting with parameters ["rclone" "ls" "mysource:myshare:" "-vv"]
2024/06/07 16:51:43 DEBUG : Creating backend with remote "mysource:myshare"
2024/06/07 16:51:43 DEBUG : Using config file from "/config/rclone/rclone.conf"
2024/06/07 16:51:43 DEBUG : pacer: low level retry 1/10 (error couldn't connect SMB: invalid response error: expected session id: 0, got 6270136581206573312)
2024/06/07 16:51:43 DEBUG : pacer: Rate limited, increasing sleep to 200ms
2024/06/07 16:51:43 DEBUG : pacer: low level retry 2/10 (error couldn't connect SMB: invalid response error: expected session id: 0, got 6414251769282429184)
2024/06/07 16:51:43 DEBUG : pacer: Rate limited, increasing sleep to 400ms
```

This patch fixes this strange behaviour of this SMB implementation. 