### PR TITLE
Fix signature verification for async STATUS_PENDING responses

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -336,21 +336,6 @@ type conn struct {
 	useSession atomic.Bool
 }
 
-//lint:ignore U1000 appears to be legacy, unsure, so leaving for now
-func (conn *conn) sendRecv(ctx context.Context, cmd uint16, req smb2.Packet) (res []byte, err error) {
-	rr, err := conn.send(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	pkt, err := conn.recv(rr)
-	if err != nil {
-		return nil, err
-	}
-
-	return accept(cmd, pkt)
-}
-
 func (conn *conn) loanCredit(ctx context.Context, payloadSize int) (creditCharge uint16, grantedPayloadSize int, err error) {
 	if conn.capabilities&smb2.SMB2_GLOBAL_CAP_LARGE_MTU == 0 {
 		creditCharge = 1
@@ -952,32 +937,45 @@ func (conn *conn) tryDecrypt(pkt []byte) ([]byte, *recvBuf, error, bool) {
 func (conn *conn) tryVerify(pkt []byte, isEncrypted bool) error {
 	p := smb2.PacketCodec(pkt)
 
-	msgId := p.MessageId()
-	s := conn.session.Load()
+	msgID := p.MessageId()
 
-	if msgId != 0xFFFFFFFFFFFFFFFF {
-		if p.Flags()&smb2.SMB2_FLAGS_SIGNED != 0 {
-			if s == nil || s.sessionId != p.SessionId() {
-				return &InvalidResponseError{"unknown session id returned"}
-			} else {
-				if !s.verify(pkt) {
-					return &InvalidResponseError{"unverified packet returned"}
-				}
-			}
-		} else {
-			if conn.requireSigning && !isEncrypted {
-				if s != nil {
-					if s.sessionFlags&(smb2.SMB2_SESSION_FLAG_IS_GUEST|smb2.SMB2_SESSION_FLAG_IS_NULL) == 0 {
-						if s.sessionId == p.SessionId() {
-							return &InvalidResponseError{"signing required"}
-						}
-					}
-				}
-			}
-		}
+	// MS-SMB2 3.2.5.1.3 states that the client MUST skip signature processing if:
+	// - MessageId is 0xFFFFFFFFFFFFFFFF
+	// - Status in the SMB2 header is STATUS_PENDING
+	// 		- 3.3.4.1.1 says servers should skip signing interim responses to async requests - STATUS_PENDING is an interim response
+	// - Client is using the SMB 3.x dialect and the message was successfully decrypted+authenticated (isEncrypted=true)
+	if msgID == 0xFFFFFFFFFFFFFFFF {
+		return nil
+	}
+	if erref.NtStatus(p.Status()) == erref.STATUS_PENDING {
+		return nil
+	}
+	if !conn.requireSigning || isEncrypted {
+		return nil
 	}
 
-	return nil
+	s := conn.session.Load()
+	if s == nil {
+		return &InvalidResponseError{"packet received before session established"}
+	}
+	if s.sessionId != p.SessionId() {
+		return &InvalidResponseError{"packet for unknown session"}
+	}
+
+	// guest and null sessions can't produce signatures, so they don't need to be verified
+	if s.sessionFlags&(smb2.SMB2_SESSION_FLAG_IS_GUEST|smb2.SMB2_SESSION_FLAG_IS_NULL) != 0 {
+		return nil
+	}
+
+	// If the signature flag is set, then we verify it
+	if p.Flags()&smb2.SMB2_FLAGS_SIGNED != 0 {
+		if !s.verify(pkt) {
+			return &InvalidResponseError{"packet failed signature verification"}
+		}
+		return nil
+	}
+
+	return &InvalidResponseError{"signing required"}
 }
 
 func (conn *conn) tryHandle(pkt []byte, e error, rb *recvBuf) error {

--- a/conn.go
+++ b/conn.go
@@ -950,7 +950,7 @@ func (conn *conn) tryVerify(pkt []byte, isEncrypted bool) error {
 	if erref.NtStatus(p.Status()) == erref.STATUS_PENDING {
 		return nil
 	}
-	if !conn.requireSigning || isEncrypted {
+	if isEncrypted {
 		return nil
 	}
 
@@ -967,15 +967,16 @@ func (conn *conn) tryVerify(pkt []byte, isEncrypted bool) error {
 		return nil
 	}
 
-	// If the signature flag is set, then we verify it
-	if p.Flags()&smb2.SMB2_FLAGS_SIGNED != 0 {
+	// verify if 1) the connection requires signing or 2) if the message itself is signed
+	if conn.requireSigning || p.Flags()&smb2.SMB2_FLAGS_SIGNED != 0 {
 		if !s.verify(pkt) {
 			return &InvalidResponseError{"packet failed signature verification"}
 		}
 		return nil
 	}
 
-	return &InvalidResponseError{"signing required"}
+	// the message was not signed AND signing is not required
+	return nil
 }
 
 func (conn *conn) tryHandle(pkt []byte, e error, rb *recvBuf) error {

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,10 +1,14 @@
 package smb2
 
 import (
+	"bytes"
 	"context"
+	"crypto/aes"
 	"net"
 	"testing"
 
+	"github.com/cloudsoda/go-smb2/internal/crypto/cmac"
+	"github.com/cloudsoda/go-smb2/internal/erref"
 	"github.com/cloudsoda/go-smb2/internal/smb2"
 	"github.com/stretchr/testify/require"
 )
@@ -63,5 +67,58 @@ func TestSessionRecv(t *testing.T) {
 		err := roundTrip(t, c, s)
 		require.Error(err)
 		require.IsType(&InvalidResponseError{}, err)
+	})
+}
+
+func TestTryVerify(t *testing.T) {
+	// builds an SMB2 response header
+	makeHdr := func(status uint32, flags uint32, sessionId, msgID uint64) []byte {
+		pkt := make([]byte, 64)
+		p := smb2.PacketCodec(pkt)
+		p.SetProtocolId()
+		p.SetStructureSize()
+		p.SetCommand(smb2.SMB2_CREATE)
+		p.SetStatus(status)
+		p.SetFlags(flags)
+		p.SetMessageId(msgID)
+		p.SetSessionId(sessionId)
+		return pkt
+	}
+
+	require := require.New(t)
+	const sessionID uint64 = 0xCAFE
+
+	// SMB 3.0.x-style signing-required conn with a CMAC verifier.
+	ciph, err := aes.NewCipher(make([]byte, 16))
+	require.NoError(err)
+
+	c := &conn{
+		outstandingRequests: newOutstandingRequests(),
+		requireSigning:      true,
+		dialect:             smb2.SMB302,
+	}
+	s := &session{conn: c, sessionId: sessionID, verifier: cmac.New(ciph)}
+	c.session.Store(s)
+
+	t.Run("STATUS_PENDING should skip verification", func(t *testing.T) {
+		pkt := makeHdr(uint32(erref.STATUS_PENDING), smb2.SMB2_FLAGS_SERVER_TO_REDIR|smb2.SMB2_FLAGS_ASYNC_COMMAND, sessionID, smb2.SMB2_CREATE)
+		require.NoError(c.tryVerify(pkt, false))
+	})
+
+	t.Run("regular message, signed flag, bad signature - should fail", func(t *testing.T) {
+		pkt := makeHdr(0, smb2.SMB2_FLAGS_SERVER_TO_REDIR|smb2.SMB2_FLAGS_SIGNED, sessionID, 21)
+		smb2.PacketCodec(pkt).SetSignature(bytes.Repeat([]byte{0x00}, 16))
+		require.IsType(&InvalidResponseError{}, c.tryVerify(pkt, false))
+	})
+
+	t.Run("regular message, unset signed flag, bad signature - should fail", func(t *testing.T) {
+		pkt := makeHdr(0, smb2.SMB2_FLAGS_SERVER_TO_REDIR, sessionID, smb2.SMB2_CREATE)
+		smb2.PacketCodec(pkt).SetSignature(bytes.Repeat([]byte{0x00}, 16))
+		require.IsType(&InvalidResponseError{}, c.tryVerify(pkt, false))
+	})
+
+	t.Run("OPLOCK_BREAK should skip verification", func(t *testing.T) {
+		pkt := makeHdr(0, smb2.SMB2_FLAGS_SERVER_TO_REDIR, sessionID, 0xFFFFFFFFFFFFFFFF)
+		require.NoError(c.tryVerify(pkt, false))
 	})
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,7 +1,6 @@
 package smb2
 
 import (
-	"bytes"
 	"context"
 	"crypto/aes"
 	"net"
@@ -72,7 +71,7 @@ func TestSessionRecv(t *testing.T) {
 
 func TestTryVerify(t *testing.T) {
 	// builds an SMB2 response header
-	makeHdr := func(status uint32, flags uint32, sessionId, msgID uint64) []byte {
+	makeHdr := func(status uint32, flags uint32, sessionId, msgID uint64) smb2.PacketCodec {
 		pkt := make([]byte, 64)
 		p := smb2.PacketCodec(pkt)
 		p.SetProtocolId()
@@ -107,18 +106,51 @@ func TestTryVerify(t *testing.T) {
 
 	t.Run("regular message, signed flag, bad signature - should fail", func(t *testing.T) {
 		pkt := makeHdr(0, smb2.SMB2_FLAGS_SERVER_TO_REDIR|smb2.SMB2_FLAGS_SIGNED, sessionID, 21)
-		smb2.PacketCodec(pkt).SetSignature(bytes.Repeat([]byte{0x00}, 16))
+		pkt.SetSignature(zero[:])
 		require.IsType(&InvalidResponseError{}, c.tryVerify(pkt, false))
 	})
 
 	t.Run("regular message, unset signed flag, bad signature - should fail", func(t *testing.T) {
 		pkt := makeHdr(0, smb2.SMB2_FLAGS_SERVER_TO_REDIR, sessionID, smb2.SMB2_CREATE)
-		smb2.PacketCodec(pkt).SetSignature(bytes.Repeat([]byte{0x00}, 16))
-		require.IsType(&InvalidResponseError{}, c.tryVerify(pkt, false))
+		pkt.SetSignature(zero[:])
+		err := c.tryVerify(pkt, false)
+		require.IsType(&InvalidResponseError{}, err)
+		require.ErrorContains(err, "packet failed signature verification")
 	})
 
 	t.Run("OPLOCK_BREAK should skip verification", func(t *testing.T) {
 		pkt := makeHdr(0, smb2.SMB2_FLAGS_SERVER_TO_REDIR, sessionID, 0xFFFFFFFFFFFFFFFF)
+		require.NoError(c.tryVerify(pkt, false))
+	})
+
+	t.Run("unsigned message, signing not negotiated - succeeds", func(t *testing.T) {
+		// we need a connection that doesn't require signing for this subtest
+		c := &conn{
+			outstandingRequests: newOutstandingRequests(),
+			dialect:             smb2.SMB302,
+		}
+		s := &session{conn: c, sessionId: sessionID}
+		c.session.Store(s)
+
+		pkt := makeHdr(0, smb2.SMB2_FLAGS_SERVER_TO_REDIR, sessionID, smb2.SMB2_CREATE)
+		require.NoError(c.tryVerify(pkt, false))
+	})
+
+	t.Run("encrypted message without signature, succeeds", func(t *testing.T) {
+		// pass an invalid session id, and use a connection that requires
+		// signing to make sure we're getting an early return due to encryption
+		pkt := makeHdr(0, smb2.SMB2_FLAGS_SERVER_TO_REDIR, 0, smb2.SMB2_CREATE)
+		require.NoError(c.tryVerify(pkt, true))
+	})
+
+	t.Run("signed message succeeds", func(t *testing.T) {
+		pkt := makeHdr(0, smb2.SMB2_FLAGS_SERVER_TO_REDIR|smb2.SMB2_FLAGS_SIGNED, sessionID, smb2.SMB2_CREATE)
+
+		// actually sign the packet
+		verifier := cmac.New(ciph)
+		verifier.Write(pkt)
+		pkt.SetSignature(verifier.Sum(nil))
+
 		require.NoError(c.tryVerify(pkt, false))
 	})
 }

--- a/internal/erref/ntstatus.go
+++ b/internal/erref/ntstatus.go
@@ -1,5 +1,6 @@
 package erref
 
+// NTStatus values are published at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55
 type NtStatus uint32
 
 func (e NtStatus) Error() string {


### PR DESCRIPTION
Per MS-SMB2 §3.3.4.1.1 / §3.2.5.1.3, servers must not sign interim STATUS_PENDING responses and clients must not verify them. tryVerify was rejecting these as "signing required" on signing-mandated SMB 3.x connections, tearing down the in-flight request whenever the server needed extra time on a CREATE (or other long-running op) and surfacing as a broken session in production.

Restructure tryVerify to:
- Hoist the spec-mandated skip cases (msgId=-1, STATUS_PENDING, signing-not-required, isEncrypted) into early returns.
- Replace silent fall-through on nil session and sessionId mismatch with explicit InvalidResponseError returns, so the function no longer depends on the sessionId guard in runReceiver as its sole line of defense.
- Move the guest/null session exemption ahead of the SIGNED-flag dispatch so a SIGNED packet on a guest/null session no longer panics the receiver goroutine on a nil verifier.

Remove the unused conn.sendRecv method, add TestTryVerify covering the STATUS_PENDING, OPLOCK_BREAK, bad-signature, and unsigned-when- required paths, and add a doc-link comment on the NtStatus type.