### PR TITLE
Security hardening: slice-panic and nil-deref fixes

### DIFF
--- a/client.go
+++ b/client.go
@@ -2312,8 +2312,11 @@ func (f *File) readdir(pattern string) (fi []os.FileInfo, err error) {
 		}
 
 		next := info.NextEntryOffset()
-		if next == 0 || uint64(next) >= uint64(len(output)) {
+		if next == 0 {
 			return fi, nil
+		}
+		if uint64(next) >= uint64(len(output)) {
+			return nil, &InvalidResponseError{"bad directory entry offset"}
 		}
 
 		output = output[next:]

--- a/internal/ntlm/challengemessage.go
+++ b/internal/ntlm/challengemessage.go
@@ -50,10 +50,11 @@ func UnmarshalChallengeMessage(cmsg, nmsg []byte, targetSPN string) (*ChallengeM
 		return nil, errors.New("invalid target name format")
 	}
 	targetNameBufferOffset := le.Uint32(cmsg[16:20]) // cmsg.TargetNameBufferOffset
-	if len(cmsg) < int(targetNameBufferOffset+uint32(targetNameLen)) {
+	targetNameEnd := uint64(targetNameBufferOffset) + uint64(targetNameLen)
+	if targetNameEnd > uint64(len(cmsg)) {
 		return nil, errors.New("invalid target name format")
 	}
-	targetName := cmsg[targetNameBufferOffset : targetNameBufferOffset+uint32(targetNameLen)] // cmsg.TargetName
+	targetName := cmsg[targetNameBufferOffset:targetNameEnd] // cmsg.TargetName
 
 	if flags&NTLMSSP_NEGOTIATE_TARGET_INFO == 0 {
 		return nil, errors.New("invalid negotiate flags")
@@ -65,10 +66,11 @@ func UnmarshalChallengeMessage(cmsg, nmsg []byte, targetSPN string) (*ChallengeM
 		return nil, errors.New("invalid target info format")
 	}
 	targetInfoBufferOffset := le.Uint32(cmsg[44:48]) // cmsg.TargetInfoBufferOffset
-	if len(cmsg) < int(targetInfoBufferOffset+uint32(targetInfoLen)) {
+	targetInfoEnd := uint64(targetInfoBufferOffset) + uint64(targetInfoLen)
+	if targetInfoEnd > uint64(len(cmsg)) {
 		return nil, errors.New("invalid target info format")
 	}
-	targetInfo := cmsg[targetInfoBufferOffset : targetInfoBufferOffset+uint32(targetInfoLen)] // cmsg.TargetInfo
+	targetInfo := cmsg[targetInfoBufferOffset:targetInfoEnd] // cmsg.TargetInfo
 	info := newTargetInfoEncoder(targetInfo, utf16le.Encode(targetSPN, utf16le.MapCharsNone))
 	if info == nil {
 		return nil, errors.New("invalid target info format")

--- a/internal/spnego/spnego.go
+++ b/internal/spnego/spnego.go
@@ -2,6 +2,7 @@ package spnego
 
 import (
 	"encoding/asn1"
+	"errors"
 
 	"github.com/geoffgarside/ber"
 )
@@ -79,6 +80,10 @@ func DecodeNegTokenInit2(bs []byte) (*NegTokenInit2, error) {
 		return nil, err
 	}
 
+	if len(init.Init2) == 0 {
+		return nil, errors.New("spnego: NegTokenInit2 missing")
+	}
+
 	return &init.Init2[0], nil
 }
 
@@ -128,6 +133,10 @@ func DecodeNegTokenInit(bs []byte) (*NegTokenInit, error) {
 	_, err := ber.UnmarshalWithParams(bs, &init, "application,tag:0")
 	if err != nil {
 		return nil, err
+	}
+
+	if len(init.Init) == 0 {
+		return nil, errors.New("spnego: NegTokenInit missing")
 	}
 
 	return &init.Init[0], nil

--- a/spnego.go
+++ b/spnego.go
@@ -45,11 +45,17 @@ func (c *spnegoClient) AcceptSecContext(negTokenRespBytes []byte) (negTokenRespB
 		return nil, err
 	}
 
-	for i, mechType := range c.mechTypes {
-		if mechType.Equal(negTokenResp.SupportedMech) {
-			c.selectedMech = c.mechs[i]
-			break
+	if len(negTokenResp.SupportedMech) != 0 {
+		for i, mechType := range c.mechTypes {
+			if mechType.Equal(negTokenResp.SupportedMech) {
+				c.selectedMech = c.mechs[i]
+				break
+			}
 		}
+	}
+
+	if c.selectedMech == nil {
+		return nil, &InvalidResponseError{"server selected an unsupported mechanism"}
 	}
 
 	responseToken, err := c.selectedMech.AcceptSecContext(negTokenResp.ResponseToken)


### PR DESCRIPTION
## Background

An internal security audit identified several denial-of-service and
process-crash vulnerabilities triggerable by a malicious or misbehaving SMB
server.

All changes are purely defensive. No public API is modified.

---

## `File.readdir()` trusts `NextEntryOffset` without bounds check

**CWE-129 · Severity: High**

### Problem

`readdir` in `client.go` advances through a directory-listing buffer using the
server-supplied `NextEntryOffset` field (`uint32`). The previous partial fix
combined end-of-listing and out-of-bounds cases into a single `return fi, nil`,
silently treating a malformed offset as end-of-directory:

```go
// BEFORE — bad offset silently treated as end of directory
if next == 0 || uint64(next) >= uint64(len(output)) {
    return fi, nil
}
```

A server returning an offset larger than the remaining buffer should be an
error, not a silent truncation. The two conditions have different semantics and
must be handled separately.

### Fix (`client.go`)

```go
// AFTER
next := info.NextEntryOffset()
if next == 0 {
    return fi, nil
}
if uint64(next) >= uint64(len(output)) {
    return nil, &InvalidResponseError{"bad directory entry offset"}
}
output = output[next:]
```

An out-of-bounds offset now returns `InvalidResponseError` to the caller,
surfacing the malformed response rather than silently dropping the remaining
entries.

---

## SPNEGO `AcceptSecContext` nil-pointer dereference on unknown `SupportedMech`

**CWE-476 · Severity: High**

### Problem

`spnegoClient.AcceptSecContext` in `spnego.go` iterated over the client's
advertised mechanism OIDs to find the one the server selected. If the server's
`SupportedMech` OID matched nothing (or was absent), `c.selectedMech` remained
`nil` and the immediately following method call panicked:

```go
// BEFORE — nil dereference if SupportedMech is unknown or absent
for i, mechType := range c.mechTypes {
    if mechType.Equal(negTokenResp.SupportedMech) {
        c.selectedMech = c.mechs[i]
        break
    }
}
responseToken, err := c.selectedMech.AcceptSecContext(...)  // panic
```

This was reachable on any TCP connection before authentication completed: a
hostile server simply advertises a mechanism OID the client never offered (e.g.
Kerberos when the client only offered NTLMSSP).

### Fix (`spnego.go`)

1. Skip the selection loop entirely when `SupportedMech` is empty (absent /
   malformed OID).
2. Guard `c.selectedMech` before use and return a descriptive error if it is
   still `nil` after the loop.

```go
if len(negTokenResp.SupportedMech) != 0 {
    for i, mechType := range c.mechTypes {
        if mechType.Equal(negTokenResp.SupportedMech) {
            c.selectedMech = c.mechs[i]
            break
        }
    }
}
if c.selectedMech == nil {
    return nil, &InvalidResponseError{"server selected an unsupported mechanism"}
}
```

---

## `DecodeNegTokenInit` / `DecodeNegTokenInit2` panic on empty BER `Init` field

**CWE-129 · Severity: High (latent)**

### Problem

Both `DecodeNegTokenInit` and `DecodeNegTokenInit2` in
`internal/spnego/spnego.go` unconditionally indexed `[0]` into the decoded
`Init` / `Init2` slice. Because both fields are declared `optional` in the
BER schema, a correctly-formed but content-free token decodes to an empty
slice, and the index panics:

```go
// BEFORE — panics when Init2 is empty
return &init.Init2[0], nil
```

While not currently reachable from the active client path (only
`DecodeNegTokenResp` is called during SPNEGO negotiation), the functions are
exported and would crash any future caller or fork that wires them into a
server-side or testing flow.

### Fix (`internal/spnego/spnego.go`)

Add a length check before each `[0]` access:

```go
// DecodeNegTokenInit2
if len(init.Init2) == 0 {
    return nil, errors.New("spnego: NegTokenInit2 missing")
}
return &init.Init2[0], nil

// DecodeNegTokenInit
if len(init.Init) == 0 {
    return nil, errors.New("spnego: NegTokenInit missing")
}
return &init.Init[0], nil
```

---

## NTLM challenge parsing: `uint32` add wraps past length check

**CWE-190, CWE-129 · Severity: High**

### Problem

`UnmarshalChallengeMessage` in `internal/ntlm/challengemessage.go` validated
and sliced the `TargetName` and `TargetInfo` fields using arithmetic performed
in `uint32`:

```go
// BEFORE — uint32 overflow bypasses bounds check
if len(cmsg) < int(targetNameBufferOffset+uint32(targetNameLen)) { ... }
targetName := cmsg[targetNameBufferOffset : targetNameBufferOffset+uint32(targetNameLen)]
```

With `targetNameBufferOffset = 0xFFFFFFFE` and `targetNameLen = 4`, the sum
wraps to `2`. The check (`len(cmsg) < 2`) passes for any non-trivial buffer,
and the subsequent slice expression `cmsg[0xFFFFFFFE:2]` panics with
`slice bounds out of range`. The same overflow was present for the
`TargetInfo` block.

This is sent by the server as part of the NTLM CHALLENGE message inside
SESSION_SETUP — reachable on every connection attempt before credentials are
derived.

### Fix (`internal/ntlm/challengemessage.go`)

Widen to `uint64` before the addition, for both `TargetName` and `TargetInfo`:

```go
// TargetName
targetNameEnd := uint64(targetNameBufferOffset) + uint64(targetNameLen)
if targetNameEnd > uint64(len(cmsg)) {
    return nil, errors.New("invalid target name format")
}
targetName := cmsg[targetNameBufferOffset:targetNameEnd]

// TargetInfo
targetInfoEnd := uint64(targetInfoBufferOffset) + uint64(targetInfoLen)
if targetInfoEnd > uint64(len(cmsg)) {
    return nil, errors.New("invalid target info format")
}
targetInfo := cmsg[targetInfoBufferOffset:targetInfoEnd]
```

The `uint64` addition cannot overflow on any supported platform, and the
slice indices are accepted by the Go runtime once the check has passed.
