### PR TITLE
Security hardening: receiver allocation cap + share-enumeration loop bound

### DIFF
--- a/client.go
+++ b/client.go
@@ -54,8 +54,15 @@ func (se *SecurityDescriptorEncoder) Size() int {
 // Dialer contains options for func (*Dialer) Dial.
 type Dialer struct {
 	MaxCreditBalance uint16 // if it's zero, clientMaxCreditBalance is used. (See feature.go for more details)
-	Negotiator       Negotiator
-	Initiator        Initiator
+	// MaxPacketSize caps the per-frame receive allocation enforced in the
+	// receiver goroutine.  If zero, the cap is derived from the server's
+	// advertised maxTransactSize / maxReadSize / maxWriteSize (plus a small
+	// overhead) once negotiation completes, falling back to 1 MiB before
+	// negotiation.  Set this to a lower value to further restrict memory
+	// usage against a potentially hostile server.
+	MaxPacketSize uint32
+	Negotiator    Negotiator
+	Initiator     Initiator
 }
 
 /*
@@ -102,6 +109,13 @@ func (d *Dialer) DialConn(ctx context.Context, tcpConn net.Conn, address string)
 	conn, err := d.Negotiator.negotiate(ctx, direct(tcpConn), a)
 	if err != nil {
 		return nil, err
+	}
+
+	// Apply any caller-supplied per-frame receive cap.  A non-zero value
+	// overrides the negotiated default; it should be no smaller than the
+	// largest expected SMB2 payload (maxReadSize + header overhead).
+	if d.MaxPacketSize != 0 {
+		conn.recvMaxSize.Store(d.MaxPacketSize)
 	}
 
 	s, err := sessionSetup(ctx, conn, d.Initiator)
@@ -286,7 +300,13 @@ func (c *Session) ListSharenames() ([]string, error) {
 				return nil, &os.PathError{Op: "listSharenames", Path: f.name, Err: &InvalidResponseError{"broken net share enum response format"}}
 			}
 
-			for r2.IsIncomplete() {
+			const maxShareEnumBytes = 1 << 20 // 1 MiB
+			const maxShareEnumIters = 64
+			for iter := 0; r2.IsIncomplete(); iter++ {
+				if iter >= maxShareEnumIters || len(output) >= maxShareEnumBytes {
+					return nil, &os.PathError{Op: "listSharenames", Path: f.name, Err: &InvalidResponseError{"share enumeration response too large"}}
+				}
+
 				n, err := f.readAt(buf, 0)
 				if err != nil {
 					return nil, &os.PathError{Op: "listSharenames", Path: f.name, Err: err}

--- a/conn.go
+++ b/conn.go
@@ -149,6 +149,21 @@ retry:
 	conn.maxWriteSize = r.MaxWriteSize()
 	conn.sequenceWindow = 1
 
+	// Compute the per-frame receive cap from the negotiated sizes.  Use the
+	// largest of the three server-advertised limits plus a small header/
+	// encryption overhead (256 bytes).  Callers may lower this further via
+	// Dialer.MaxPacketSize after negotiate returns.
+	{
+		maxPkt := conn.maxTransactSize
+		if conn.maxReadSize > maxPkt {
+			maxPkt = conn.maxReadSize
+		}
+		if conn.maxWriteSize > maxPkt {
+			maxPkt = conn.maxWriteSize
+		}
+		conn.recvMaxSize.Store(maxPkt + 256)
+	}
+
 	// conn.gssNegotiateToken = r.SecurityBuffer()
 	// conn.clientGuid = n.ClientGuid
 	// copy(conn.serverGuid[:], r.ServerGuid())
@@ -324,6 +339,12 @@ type conn struct {
 	recvPool      sync.Pool // reusable receive buffers
 	encodeBuf     []byte    // retained request encoding buffer; reused under conn.m
 	compoundSizes []int     // retained sizes buffer for compound requests; reused under conn.m
+
+	// recvMaxSize is the per-frame allocation cap enforced in runReceiver.
+	// Zero means "use the pre-negotiation fallback" (1 MiB).  Set to the
+	// negotiated max once NEGOTIATE completes; may be overridden lower by
+	// Dialer.MaxPacketSize.
+	recvMaxSize atomic.Uint32
 
 	m sync.Mutex
 
@@ -716,6 +737,27 @@ func (conn *conn) runReceiver() {
 		if e != nil {
 			err = &TransportError{e}
 
+			goto exit
+		}
+
+		// Reject frames that are too small to contain a valid header.
+		// A TRANSFORM_HEADER is 52 bytes; a plain SMB2 header is 64 bytes.
+		// Anything smaller cannot be a well-formed packet.
+		if n < 52 {
+			err = &InvalidResponseError{"frame size too small"}
+			goto exit
+		}
+
+		// Enforce an upper bound on per-frame allocations to prevent a
+		// hostile server from driving unbounded memory pressure.
+		// recvMaxSize is 0 before negotiation completes; fall back to 1 MiB.
+		const prenegotiateMaxPacket uint32 = 1 << 20 // 1 MiB
+		limit := conn.recvMaxSize.Load()
+		if limit == 0 {
+			limit = prenegotiateMaxPacket
+		}
+		if uint32(n) > limit {
+			err = &InvalidResponseError{"frame size exceeds limit"}
 			goto exit
 		}
 


### PR DESCRIPTION
## Background

An internal security audit identified two medium-severity denial-of-service
vulnerabilities triggerable by a malicious or misbehaving SMB server. This PR
addresses both. No public API is broken; all existing behaviour is preserved
for well-formed servers.

---

## Fix 1 — Receiver allocates server-specified packet size on every frame

**CWE-400, CWE-789 · Severity: Medium**

### Problem

`runReceiver` in `conn.go` allocated a buffer of exactly the size advertised
in the transport framing header before any other validation:

```go
// BEFORE
n, e := conn.t.ReadSize()   // n is fully attacker-controlled, up to 16 MiB
...
rb = &recvBuf{b: make([]byte, n)}
```

`ReadSize` is capped by `maxDirectTCPSize = 0xFFFFFF` (16 MiB) in the
transport layer, but that was the only limit. A hostile server could loop
sending framing sizes of 16 MiB with a garbage payload; each frame caused a
16 MiB allocation that was discarded only after header validation. The
receiver goroutine loops continuously, so a single connection could drive
~16 MiB × (server-controlled rate) of allocator churn.

There was also no lower bound: a server sending millions of 4-byte frames
amplified GC pressure without triggering the pool's capacity check.

### Fix

Three coordinated changes:

**`conn` struct** — new `recvMaxSize atomic.Uint32` field stores the
per-frame cap, shared safely between `negotiate` (writer) and `runReceiver`
(reader).

**`negotiate()`** — after storing the server-advertised sizes, computes the
cap as `max(maxTransactSize, maxReadSize, maxWriteSize) + 256` and stores it
atomically. This ensures the cap reflects the negotiated session rather than
a hardcoded constant.

**`runReceiver()`** — two new guards applied before any buffer is allocated:

```go
// Reject frames smaller than a TRANSFORM_HEADER (52 bytes).
if n < 52 {
    err = &InvalidResponseError{"frame size too small"}
    goto exit
}

// Enforce upper bound. Falls back to 1 MiB before negotiation completes.
limit := conn.recvMaxSize.Load()
if limit == 0 {
    limit = prenegotiateMaxPacket // 1 MiB
}
if uint32(n) > limit {
    err = &InvalidResponseError{"frame size exceeds limit"}
    goto exit
}
```

Both violations cause a clean connection shutdown (via `goto exit`) rather
than a silent continue, so pending callers are unblocked immediately.

**`Dialer`** — new `MaxPacketSize uint32` field. When non-zero it overrides
the negotiated cap after `negotiate` returns, allowing callers to enforce a
stricter ceiling against potentially hostile servers:

```go
type Dialer struct {
    ...
    // MaxPacketSize caps the per-frame receive allocation enforced in the
    // receiver goroutine. If zero, the cap is derived from the server's
    // advertised maxTransactSize / maxReadSize / maxWriteSize (plus a small
    // overhead) once negotiation completes, falling back to 1 MiB before
    // negotiation. Set this to a lower value to further restrict memory
    // usage against a potentially hostile server.
    MaxPacketSize uint32
    ...
}
```

### Files changed

- `conn.go` — `conn` struct, `negotiate()`, `runReceiver()`
- `client.go` — `Dialer` struct, `DialConn()`

---

## Fix 2 — `Share.ListSharenames` loop has no termination guarantee

**CWE-835, CWE-400 · Severity: Medium**

### Problem

`listSharenames` in `client.go` reassembled a fragmented MSRPC
`NetShareEnumAll` response by looping until `r2.IsIncomplete()` returned
false:

```go
// BEFORE
for r2.IsIncomplete() {
    n, err := f.readAt(buf, 0)
    ...
    output = append(output, r3.Buffer()...)
    r2 = msrpc.NetShareEnumAllResponseDecoder(output)
}
```

`IsIncomplete` inspects a server-supplied count/offset structure. A hostile
server can craft fragments that keep `IsIncomplete` returning `true`
indefinitely, with each iteration appending up to ~4 KiB to `output`. The
loop had no upper bound on iterations or on the total size of `output`,
leading to unbounded heap growth on a single `ListSharenames` call.

### Fix

Two hard ceilings are checked at the top of each iteration:

```go
const maxShareEnumBytes = 1 << 20 // 1 MiB
const maxShareEnumIters = 64

for iter := 0; r2.IsIncomplete(); iter++ {
    if iter >= maxShareEnumIters || len(output) >= maxShareEnumBytes {
        return nil, &os.PathError{..., Err: &InvalidResponseError{"share enumeration response too large"}}
    }
    ...
}
```

- **`maxShareEnumIters = 64`** — no legitimate share enumeration requires
  more than 64 continuation fragments.
- **`maxShareEnumBytes = 1 MiB`** — the accumulated response buffer is
  capped at 1 MiB; a typical Windows or Samba server returns well under
  100 KiB even for servers with hundreds of shares.

Either limit triggers an `InvalidResponseError` that propagates to the caller
as an `*os.PathError`, consistent with all other error returns in the function.

### Files changed

- `client.go` — `listSharenames()`
