### PR TITLE
Security hardening: receiver hang fix, constant-time MAC, transform-header validation, SPNEGO bounds checks

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -696,6 +696,14 @@ func (conn *conn) runSender() {
 	}
 }
 
+// maxConsecutiveReceiverSkips is the number of consecutive malformed or
+// unrecognised frames the receiver tolerates before treating the connection as
+// broken and shutting it down.  Each successfully delivered frame resets the
+// counter.  A malicious server can otherwise cause pending callers to hang
+// forever by flooding the connection with junk while never responding to the
+// outstanding request's MessageId.
+const maxConsecutiveReceiverSkips = 5
+
 func (conn *conn) runReceiver() {
 	var err error
 
@@ -710,6 +718,8 @@ func (conn *conn) runReceiver() {
 			close(conn.wdone)
 		}
 	}()
+
+	consecutiveSkips := 0
 
 	for {
 		n, e := conn.t.ReadSize()
@@ -746,6 +756,11 @@ func (conn *conn) runReceiver() {
 
 				logger.Println("skip:", e)
 
+				consecutiveSkips++
+				if consecutiveSkips >= maxConsecutiveReceiverSkips {
+					err = &InvalidResponseError{"too many consecutive malformed packets; closing connection"}
+					goto exit
+				}
 				continue
 			}
 
@@ -763,6 +778,11 @@ func (conn *conn) runReceiver() {
 
 					logger.Println("skip:", &InvalidResponseError{"unknown session id"})
 
+					consecutiveSkips++
+					if consecutiveSkips >= maxConsecutiveReceiverSkips {
+						err = &InvalidResponseError{"too many consecutive malformed packets; closing connection"}
+						goto exit
+					}
 					continue
 				}
 			}
@@ -775,6 +795,11 @@ func (conn *conn) runReceiver() {
 		if !hasSession && p.IsInvalid() {
 			conn.freePoolBuf(rb)
 			logger.Println("skip:", &InvalidResponseError{"invalid packet header"})
+			consecutiveSkips++
+			if consecutiveSkips >= maxConsecutiveReceiverSkips {
+				err = &InvalidResponseError{"too many consecutive malformed packets; closing connection"}
+				goto exit
+			}
 			continue
 		}
 
@@ -785,6 +810,13 @@ func (conn *conn) runReceiver() {
 			}
 			if e = conn.tryHandle(pkt, e, rb); e != nil {
 				logger.Println("skip:", e)
+				consecutiveSkips++
+				if consecutiveSkips >= maxConsecutiveReceiverSkips {
+					err = &InvalidResponseError{"too many consecutive malformed packets; closing connection"}
+					goto exit
+				}
+			} else {
+				consecutiveSkips = 0
 			}
 		} else {
 			// Compound response: sub-responses share the underlying
@@ -793,6 +825,7 @@ func (conn *conn) runReceiver() {
 			// will be GC'd once all consumers finish with their pkt slices.
 
 			var next []byte
+			frameDelivered := false
 			for {
 				// validate each segment before reading its header fields.
 				if p.IsInvalid() {
@@ -817,6 +850,8 @@ func (conn *conn) runReceiver() {
 				}
 				if e = conn.tryHandle(pkt, e, nil); e != nil {
 					logger.Println("skip:", e)
+				} else {
+					frameDelivered = true
 				}
 
 				if next == nil {
@@ -825,6 +860,15 @@ func (conn *conn) runReceiver() {
 
 				pkt = next
 				p = smb2.PacketCodec(pkt)
+			}
+			if frameDelivered {
+				consecutiveSkips = 0
+			} else {
+				consecutiveSkips++
+				if consecutiveSkips >= maxConsecutiveReceiverSkips {
+					err = &InvalidResponseError{"too many consecutive malformed packets; closing connection"}
+					goto exit
+				}
 			}
 		}
 	}

--- a/internal/spnego/spnego.go
+++ b/internal/spnego/spnego.go
@@ -2,6 +2,7 @@ package spnego
 
 import (
 	"encoding/asn1"
+	"errors"
 
 	"github.com/geoffgarside/ber"
 )
@@ -149,11 +150,26 @@ func EncodeNegTokenResp(state asn1.Enumerated, typ asn1.ObjectIdentifier, token,
 		return nil, err
 	}
 
+	// bs is an ASN.1 DER/BER value whose first byte is the tag (0x60 for
+	// APPLICATION 0) and whose subsequent bytes encode the length. We need
+	// to skip the tag+length prefix to return the inner SEQUENCE payload.
+	//
+	// Defensive bounds checks are required here even though bs is produced
+	// by asn1.Marshal (library-generated): a future caller could pass short
+	// or empty input, and the BER long-form length field can encode values
+	// up to 127 additional bytes, making skip grow well past len(bs).
+	if len(bs) < 2 {
+		return nil, errors.New("spnego: EncodeNegTokenResp: marshalled output too short")
+	}
 	skip := 1
 	if bs[skip] < 128 {
 		skip += 1
 	} else {
-		skip += int(bs[skip]) - 128 + 1
+		n := int(bs[skip]) - 128 + 1
+		skip += n
+	}
+	if skip > len(bs) {
+		return nil, errors.New("spnego: EncodeNegTokenResp: length prefix exceeds buffer")
 	}
 
 	return bs[skip:], nil

--- a/session.go
+++ b/session.go
@@ -1,12 +1,10 @@
 package smb2
 
 import (
-	"bytes"
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
-
 	"crypto/sha256"
 	"crypto/sha512"
 	"fmt"
@@ -104,7 +102,6 @@ func sessionSetup(ctx context.Context, conn *conn, i Initiator) (*session, error
 				h.Sum(s.preauthIntegrityHashValue[:0])
 			}
 		}
-
 	}
 
 	outputToken, err = spnego.AcceptSecContext(r.SecurityBuffer())
@@ -371,7 +368,7 @@ func (s *session) verify(pkt []byte) (ok bool) {
 
 	p.SetSignature(h.Sum(nil))
 
-	return bytes.Equal(signature, p.Signature())
+	return hmac.Equal(signature, p.Signature())
 }
 
 // encrypt encrypts pkt into c. len(c) must equal 52+len(pkt)+16.
@@ -401,6 +398,18 @@ func (s *session) encrypt(pkt, c []byte) ([]byte, error) {
 // ciphertext and tag into c and decrypts in-place.
 func (s *session) decrypt(pkt, c []byte) ([]byte, error) {
 	t := smb2.TransformCodec(pkt)
+
+	// MS-SMB2 §3.3.5.2.7: OriginalMessageSize must equal the plaintext
+	// length (ciphertext minus AEAD tag).
+	overhead := s.decrypter.Overhead()
+	encLen := len(t.EncryptedData())
+	if encLen < overhead {
+		return nil, &InvalidResponseError{"transform header: encrypted payload too short"}
+	}
+	expectedPlainLen := encLen - overhead
+	if uint32(expectedPlainLen) != t.OriginalMessageSize() {
+		return nil, &InvalidResponseError{"transform header: OriginalMessageSize mismatch"}
+	}
 
 	c = c[:0]
 	c = append(c, t.EncryptedData()...)


### PR DESCRIPTION
## Background

An internal security audit identified four low-to-medium severity
vulnerabilities in the SMB2/3 client implementation. This PR addresses all
four. No public API is modified; all changes are purely defensive.

---

## Fix 1 — Receiver swallows malformed packets; pending callers hang forever

**CWE-833 (Deadlock) / CWE-400 · Severity: Medium**

### Problem

`runReceiver` in `conn.go` treated every unrecognised or malformed inbound
packet as a non-fatal event: it logged a `skip:` message and continued the
receive loop. This meant that any outstanding caller blocked on `(*conn).recv`
could hang indefinitely if the server kept sending junk instead of the
expected response, because `outstandingRequests.shutdown` was never called
during the loop.

A malicious server could trigger this deliberately by sending garbage framed
at the correct message ID, causing the registered `requestResponse` to remain
in the outstanding-requests map without ever receiving a reply or an error.
Callers that did not attach a `context.Context` with a deadline (the common
case for internal helpers) would then block forever.

### Fix (`conn.go`)

A `consecutiveSkips` counter is initialised before the receive loop. Every
skip site — `tryDecrypt` failure, session-ID mismatch, invalid header, and
`tryHandle` returning an error — increments the counter and checks it against
the new package-level constant `maxConsecutiveReceiverSkips = 5`. When the
threshold is reached, the receiver treats the connection as broken:

```go
// AFTER — each skip site
consecutiveSkips++
if consecutiveSkips >= maxConsecutiveReceiverSkips {
    err = &InvalidResponseError{"too many consecutive malformed packets; closing connection"}
    goto exit
}
```

`goto exit` reaches the existing shutdown path that calls
`conn.outstandingRequests.shutdown(err)`, unblocking every pending caller with
the error. A successfully delivered frame (either single or at least one
segment of a compound) resets the counter to zero, so transient noise from a
well-behaved server does not trigger a disconnect.

The same guard is applied consistently to all five skip paths:

| Condition                           | Action before    | Action after                             |
| ----------------------------------- | ---------------- | ---------------------------------------- |
| `tryDecrypt` error                  | log + `continue` | log + increment + check, then `continue` |
| Session-ID mismatch                 | log + `continue` | log + increment + check, then `continue` |
| Invalid pre-session header          | log + `continue` | log + increment + check, then `continue` |
| Single-response `tryHandle` error   | log + `continue` | log + increment + check, then `continue` |
| Compound: no segment delivered      | (not tracked)    | increment + check after inner loop       |
| Compound/single: delivery succeeded | (not tracked)    | reset counter to 0                       |

---

## Fix 2 — Non-constant-time MAC comparison in `session.verify`

**CWE-208 (Observable Timing Discrepancy) · Severity: Low**

### Problem

`session.verify` in `session.go` compared the computed SMB2 signature against
the server-supplied signature using `bytes.Equal`:

```go
// BEFORE
return bytes.Equal(signature, p.Signature())
```

`bytes.Equal` is not guaranteed to run in constant time. For SMB2 signing
(HMAC-SHA256 in dialects 2.0.2/2.1, AES-CMAC in 3.x), this leaks
byte-by-byte equality information through timing side-channels. While
exploitability is low in this direction (the server already knows its own
signing key), the comparison should be constant-time for hygiene and to
eliminate any theoretical oracle the library could provide to a passive
network observer or a compromised server.

### Fix (`session.go`)

Replaced `bytes.Equal` with `hmac.Equal`, which uses
`crypto/subtle.ConstantTimeCompare` internally:

```go
// AFTER
return hmac.Equal(signature, p.Signature())
```

The now-unused `"bytes"` import was removed.

---

## Fix 3 — `TRANSFORM_HEADER` `OriginalMessageSize` not validated before decryption

**CWE-20 (Improper Input Validation) · Severity: Low**

### Problem

`session.decrypt` in `session.go` decrypted SMB3 transform packets without
validating the `OriginalMessageSize` field declared in the header against the
actual length of the ciphertext. MS-SMB2 §3.3.5.2.7 requires the receiver to
verify this before processing the decrypted payload.

Concretely, if the encrypted payload was shorter than the AEAD authentication
tag (`Overhead()` bytes), `decrypter.Open` would receive a negative-length
slice or an impossibly small buffer, which could panic or produce garbage.
Additionally, a mismatch between the declared plaintext size and the actual
decrypted length could mislead any future consumer of `OriginalMessageSize`.

### Fix (`session.go`)

Two guards are added at the start of `session.decrypt`, before any data is
copied or the AEAD is invoked:

```go
// Reject encrypted payloads that are too short to contain the AEAD tag.
overhead := s.decrypter.Overhead()
encLen := len(t.EncryptedData())
if encLen < overhead {
    return nil, &InvalidResponseError{"transform header: encrypted payload too short"}
}

// MS-SMB2 §3.3.5.2.7: OriginalMessageSize must equal the plaintext length.
expectedPlainLen := encLen - overhead
if uint32(expectedPlainLen) != t.OriginalMessageSize() {
    return nil, &InvalidResponseError{"transform header: OriginalMessageSize mismatch"}
}
```

---

## Fix 4 — `EncodeNegTokenResp` indexes marshalled output without bounds checks

**CWE-129 · Severity: Low (defence in depth)**

### Problem

`EncodeNegTokenResp` in `internal/spnego/spnego.go` parsed the BER
tag-length prefix of the `asn1.Marshal` output using unchecked index
expressions:

```go
// BEFORE
skip := 1
if bs[skip] < 128 {       // panics if len(bs) < 2
    skip += 1
} else {
    skip += int(bs[skip]) - 128 + 1  // skip can grow to 255+ before the check
}
return bs[skip:], nil     // panics if skip > len(bs)
```

`bs` is library-generated so a malicious network input cannot directly
influence this code path today. However:

- If `asn1.Marshal` ever returned a one-byte or empty buffer (e.g. due to an
  empty SEQUENCE), `bs[1]` would panic immediately.
- The BER long-form length encoding can push `skip` up to `128 + 127 = 255`
  bytes; if the buffer is shorter than that the final `bs[skip:]` panics.

Any future caller, fork, or refactoring that reaches this code with short or
unexpected input would inherit the panic.

### Fix (`internal/spnego/spnego.go`)

Added explicit length checks at both indexing points:

```go
// AFTER
if len(bs) < 2 {
    return nil, errors.New("spnego: EncodeNegTokenResp: marshalled output too short")
}
skip := 1
if bs[skip] < 128 {
    skip += 1
} else {
    n := int(bs[skip]) - 128 + 1
    skip += n
}
if skip > len(bs) {
    return nil, errors.New("spnego: EncodeNegTokenResp: length prefix exceeds buffer")
}
return bs[skip:], nil
```

The `"errors"` package import was added.
