### PR TITLE
Surface the server's file id in FileStat

### DIFF
--- a/client.go
+++ b/client.go
@@ -1722,6 +1722,7 @@ func (f *File) stat() (os.FileInfo, error) {
 		EndOfFile:      std.EndOfFile(),
 		AllocationSize: std.AllocationSize(),
 		FileAttributes: basic.FileAttributes(),
+		FileId:         uint64(info.InternalInformation().IndexNumber()),
 		FileName:       base(f.name),
 	}, nil
 }
@@ -2252,7 +2253,7 @@ func (f *File) ioctl(req *smb2.IoctlRequest) (output []byte, err error) {
 
 func (f *File) readdir(pattern string) (fi []os.FileInfo, err error) {
 	req := &smb2.QueryDirectoryRequest{
-		FileInfoClass:      smb2.FileDirectoryInformation,
+		FileInfoClass:      smb2.FileIdBothDirectoryInformation,
 		Flags:              0,
 		FileIndex:          0,
 		OutputBufferLength: uint32(f.maxTransactSize()),
@@ -2291,7 +2292,7 @@ func (f *File) readdir(pattern string) (fi []os.FileInfo, err error) {
 	output := r.OutputBuffer()
 
 	for {
-		info := smb2.FileDirectoryInformationDecoder(output)
+		info := smb2.FileIdBothDirectoryInformationDecoder(output)
 		if info.IsInvalid() {
 			return nil, &InvalidResponseError{"broken query directory response format"}
 		}
@@ -2307,6 +2308,7 @@ func (f *File) readdir(pattern string) (fi []os.FileInfo, err error) {
 				EndOfFile:      info.EndOfFile(),
 				AllocationSize: info.AllocationSize(),
 				FileAttributes: info.FileAttributes(),
+				FileId:         info.FileId(),
 				FileName:       name,
 			})
 		}
@@ -2466,7 +2468,17 @@ type FileStat struct {
 	EndOfFile      int64
 	AllocationSize int64
 	FileAttributes uint32
-	FileName       string
+	// FileId is the server's 64-bit file reference number (the MFT record plus
+	// sequence number on NTFS, the inode number on Samba). It is populated by
+	// File.Readdir, File.ReaddirPlus and File.Stat.
+	//
+	// It is 0 from Share.Stat and Share.Lstat, which report the stat carried by
+	// the CREATE response rather than issuing a separate query, and that
+	// response has no file id; obtain one via File.Stat on an open handle. It
+	// is also 0 when the server itself supplies none, as some legacy and
+	// non-native backends do.
+	FileId   uint64
+	FileName string
 }
 
 func (fs *FileStat) Name() string {

--- a/internal/smb2/fscc.go
+++ b/internal/smb2/fscc.go
@@ -349,6 +349,85 @@ func (c FileDirectoryInformationDecoder) FileName(mc utf16le.MapChars) string {
 	return utf16le.Decode(c[64:64+c.FileNameLength()], mc)
 }
 
+// FileIdBothDirectoryInformationDecoder decodes a FILE_ID_BOTH_DIR_INFORMATION
+// entry (MS-FSCC 2.4.17). Its first 64 bytes are laid out identically to
+// FILE_DIRECTORY_INFORMATION; the trailing fields add the short name and the
+// server's 64-bit file reference number.
+type FileIdBothDirectoryInformationDecoder []byte
+
+func (c FileIdBothDirectoryInformationDecoder) IsInvalid() bool {
+	if len(c) < 104 {
+		return true
+	}
+	return uint64(len(c)) < 104+uint64(c.FileNameLength())
+}
+
+func (c FileIdBothDirectoryInformationDecoder) NextEntryOffset() uint32 {
+	return le.Uint32(c[:4])
+}
+
+// FileIndex is the resume cookie for restarting enumeration, not a file
+// identifier; it is commonly 0. See FileId for the file reference number.
+func (c FileIdBothDirectoryInformationDecoder) FileIndex() uint32 {
+	return le.Uint32(c[4:8])
+}
+
+func (c FileIdBothDirectoryInformationDecoder) CreationTime() FiletimeDecoder {
+	return FiletimeDecoder(c[8:16])
+}
+
+func (c FileIdBothDirectoryInformationDecoder) LastAccessTime() FiletimeDecoder {
+	return FiletimeDecoder(c[16:24])
+}
+
+func (c FileIdBothDirectoryInformationDecoder) LastWriteTime() FiletimeDecoder {
+	return FiletimeDecoder(c[24:32])
+}
+
+func (c FileIdBothDirectoryInformationDecoder) ChangeTime() FiletimeDecoder {
+	return FiletimeDecoder(c[32:40])
+}
+
+func (c FileIdBothDirectoryInformationDecoder) EndOfFile() int64 {
+	return int64(le.Uint64(c[40:48]))
+}
+
+func (c FileIdBothDirectoryInformationDecoder) AllocationSize() int64 {
+	return int64(le.Uint64(c[48:56]))
+}
+
+func (c FileIdBothDirectoryInformationDecoder) FileAttributes() uint32 {
+	return le.Uint32(c[56:60])
+}
+
+func (c FileIdBothDirectoryInformationDecoder) FileNameLength() uint32 {
+	return le.Uint32(c[60:64])
+}
+
+func (c FileIdBothDirectoryInformationDecoder) EaSize() uint32 {
+	return le.Uint32(c[64:68])
+}
+
+func (c FileIdBothDirectoryInformationDecoder) ShortNameLength() uint8 {
+	return c[68]
+}
+
+func (c FileIdBothDirectoryInformationDecoder) ShortName(mc utf16le.MapChars) string {
+	n := min(uint64(c.ShortNameLength()), 24)
+	return utf16le.Decode(c[70:70+n], mc)
+}
+
+// FileId is the server's 64-bit file reference number: the MFT record plus
+// sequence number on NTFS, the inode number on Samba. Servers that cannot
+// supply one report 0.
+func (c FileIdBothDirectoryInformationDecoder) FileId() uint64 {
+	return le.Uint64(c[96:104])
+}
+
+func (c FileIdBothDirectoryInformationDecoder) FileName(mc utf16le.MapChars) string {
+	return utf16le.Decode(c[104:104+c.FileNameLength()], mc)
+}
+
 type FileRenameInformationType2Encoder struct {
 	ReplaceIfExists uint8
 	RootDirectory   uint64

--- a/internal/smb2/fscc_test.go
+++ b/internal/smb2/fscc_test.go
@@ -1,0 +1,59 @@
+package smb2
+
+import (
+	"testing"
+
+	"github.com/cloudsoda/go-smb2/internal/utf16le"
+	"github.com/stretchr/testify/require"
+)
+
+// buildIdBothDirInfo encodes a FILE_ID_BOTH_DIR_INFORMATION entry (MS-FSCC
+// 2.4.17) with the given file id and name, so the decoder's offsets can be
+// checked against an independently laid-out buffer.
+func buildIdBothDirInfo(fileID uint64, name string) []byte {
+	nameBytes := utf16le.Encode(name, utf16le.MapCharsNone)
+
+	b := make([]byte, 104+len(nameBytes))
+	le.PutUint32(b[0:4], 0)      // NextEntryOffset
+	le.PutUint32(b[4:8], 7)      // FileIndex (resume cookie, not the file id)
+	le.PutUint64(b[40:48], 1234) // EndOfFile
+	le.PutUint64(b[48:56], 4096) // AllocationSize
+	le.PutUint32(b[56:60], 0x20) // FileAttributes
+	le.PutUint32(b[60:64], uint32(len(nameBytes)))
+	le.PutUint64(b[96:104], fileID)
+	copy(b[104:], nameBytes)
+
+	return b
+}
+
+func TestFileIdBothDirectoryInformationDecoder(t *testing.T) {
+	const (
+		fileID = uint64(0x0004000000047FD3)
+		name   = "hello.txt"
+	)
+
+	require := require.New(t)
+
+	c := FileIdBothDirectoryInformationDecoder(buildIdBothDirInfo(fileID, name))
+
+	require.False(c.IsInvalid())
+	require.Equal(fileID, c.FileId())
+	require.Equal(name, c.FileName(utf16le.MapCharsNone))
+	require.EqualValues(7, c.FileIndex())
+	require.EqualValues(1234, c.EndOfFile())
+	require.EqualValues(4096, c.AllocationSize())
+	require.EqualValues(0x20, c.FileAttributes())
+}
+
+// A truncated entry must be rejected rather than panicking, since the buffer
+// comes straight off the wire.
+func TestFileIdBothDirectoryInformationDecoderIsInvalid(t *testing.T) {
+	require := require.New(t)
+
+	full := buildIdBothDirInfo(1, "hello.txt")
+
+	for _, n := range []int{0, 63, 64, 103, len(full) - 1} {
+		require.True(FileIdBothDirectoryInformationDecoder(full[:n]).IsInvalid(),
+			"truncation to %d bytes not reported invalid", n)
+	}
+}


### PR DESCRIPTION
FileStat carried no file identifier, so callers had nothing to use as an inode number. The value we want is the SMB2 FileId (IndexNumber in some info classes): the server's 64-bit file reference number, which is the MFT record plus sequence on NTFS and the Unix inode on Samba. It is the same value Windows reports as nFileIndexHigh/Low, so adopting it gives parity with a local scan of the same tree by construction.

readdir() requested FileDirectoryInformation, which does not carry the id at all. (Its FileIndex field is a resume cookie for restarting enumeration, not an identifier, and is almost always 0.) Switch to FileIdBothDirectoryInformation, the class Windows Explorer uses: same request, same single round trip, same enumeration, but a richer per-entry structure that includes the 8-byte FileId. Both harvest paths — Readdir and ReaddirPlus — funnel through this one readdir(), so the single switch covers both.

Querying FileInternalInformation instead would need an open handle per file, a round trip each, which is the sequential cost the compound harvest exists to avoid.

File.stat() also populates FileId, from the InternalInformation already embedded in the FileAllInformation response it issues, so File.Stat() and Readdir agree on the same file at no extra cost. Share.Stat() and Share.Lstat() continue to report 0: they return the stat carried by the CREATE response instead of issuing a query, and that response has no file id. Giving them one would mean an extra round trip on every path-based stat, which is not worth it for a field most callers ignore, so the asymmetry is documented on the field instead.

Servers that cannot supply an id report 0, which is what callers had before, so a non-supporting server degrades rather than erroring. On ReFS, ids are 128-bit and this is a truncation that can rarely collide; 64 bits is still the right width for parity, since the local Windows call yields no more than that.

Verified against Samba: readdir ids match the server's inode numbers exactly, over directories and regular files, and agree entry-for-entry with File.Stat(), which derives the id from a different info class.