### PR TITLE
Fix credit double settlement

### DIFF
--- a/client.go
+++ b/client.go
@@ -1152,11 +1152,6 @@ func (fs *Share) createFile(name string, req *smb2.CreateRequest, followSymlinks
 	}
 
 	req.CreditCharge, _, err = fs.loanCredit(0)
-	defer func() {
-		if err != nil {
-			fs.chargeCredit(req.CreditCharge)
-		}
-	}()
 	if err != nil {
 		return nil, err
 	}
@@ -1181,11 +1176,6 @@ func (fs *Share) createFile(name string, req *smb2.CreateRequest, followSymlinks
 func (fs *Share) createFileRec(name string, req *smb2.CreateRequest) (f *File, err error) {
 	for range clientMaxSymlinkDepth {
 		req.CreditCharge, _, err = fs.loanCredit(0)
-		defer func() {
-			if err != nil {
-				fs.chargeCredit(req.CreditCharge)
-			}
-		}()
 		if err != nil {
 			return nil, err
 		}
@@ -1247,17 +1237,7 @@ func evalSymlinkError(name string, errData []byte, mc utf16le.MapChars) (string,
 }
 
 func (fs *Share) sendRecv(cmd uint16, req smb2.Packet) (res []byte, err error) {
-	rr, err := fs.send(fs.ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	pkt, err := fs.recv(rr)
-	if err != nil {
-		return nil, err
-	}
-
-	return accept(cmd, pkt)
+	return fs.treeConn.sendRecv(fs.ctx, cmd, req)
 }
 
 func (fs *Share) loanCredit(payloadSize int) (creditCharge uint16, grantedPayloadSize int, err error) {
@@ -1299,7 +1279,11 @@ func (f *File) close() error {
 		Flags: 0,
 	}
 
-	req.CreditCharge = 1
+	var err error
+	req.CreditCharge, _, err = f.fs.loanCredit(0)
+	if err != nil {
+		return err
+	}
 
 	req.FileId = f.fd
 
@@ -1463,11 +1447,6 @@ func (f *File) readAt(b []byte, off int64) (n int, err error) {
 
 func (f *File) readAtChunk(n int, off int64) (bs []byte, isEOF bool, rr *requestResponse, err error) {
 	creditCharge, m, err := f.fs.loanCredit(n)
-	defer func() {
-		if err != nil {
-			f.fs.chargeCredit(creditCharge)
-		}
-	}()
 	if err != nil {
 		return nil, false, nil, err
 	}
@@ -1809,11 +1788,6 @@ func (f *File) Sync() (err error) {
 	req.FileId = f.fd
 
 	req.CreditCharge, _, err = f.fs.loanCredit(0)
-	defer func() {
-		if err != nil {
-			f.fs.chargeCredit(req.CreditCharge)
-		}
-	}()
 	if err != nil {
 		return &os.PathError{Op: "sync", Path: f.name, Err: err}
 	}
@@ -1981,11 +1955,6 @@ func (f *File) writeAt(b []byte, off int64) (n int, err error) {
 // writeAt allows partial write
 func (f *File) writeAtChunk(b []byte, off int64) (n int, err error) {
 	creditCharge, m, err := f.fs.loanCredit(len(b))
-	defer func() {
-		if err != nil {
-			f.fs.chargeCredit(creditCharge)
-		}
-	}()
 	if err != nil {
 		return 0, err
 	}
@@ -2222,11 +2191,6 @@ func (f *File) ioctl(req *smb2.IoctlRequest) (output []byte, err error) {
 	}
 
 	req.CreditCharge, _, err = f.fs.loanCredit(payloadSize)
-	defer func() {
-		if err != nil {
-			f.fs.chargeCredit(req.CreditCharge)
-		}
-	}()
 	if err != nil {
 		return nil, err
 	}
@@ -2267,11 +2231,6 @@ func (f *File) readdir(pattern string) (fi []os.FileInfo, err error) {
 	}
 
 	req.CreditCharge, _, err = f.fs.loanCredit(payloadSize)
-	defer func() {
-		if err != nil {
-			f.fs.chargeCredit(req.CreditCharge)
-		}
-	}()
 	if err != nil {
 		return nil, err
 	}
@@ -2331,11 +2290,6 @@ func (f *File) queryInfo(req *smb2.QueryInfoRequest) (infoBytes []byte, err erro
 	}
 
 	req.CreditCharge, _, err = f.fs.loanCredit(payloadSize)
-	defer func() {
-		if err != nil {
-			f.fs.chargeCredit(req.CreditCharge)
-		}
-	}()
 	if err != nil {
 		return nil, err
 	}
@@ -2403,11 +2357,6 @@ func (f *File) SetSecurityInfoRaw(flags SecurityInformationRequestFlags, sd smb2
 
 	var err error
 	req.CreditCharge, _, err = f.fs.loanCredit(req.Size())
-	defer func() {
-		if err != nil {
-			f.fs.chargeCredit(req.CreditCharge)
-		}
-	}()
 	if err != nil {
 		return fmt.Errorf("calling loanCredit: %w", err)
 	}
@@ -2428,11 +2377,6 @@ func (f *File) setInfo(req *smb2.SetInfoRequest) (err error) {
 	}
 
 	req.CreditCharge, _, err = f.fs.loanCredit(payloadSize)
-	defer func() {
-		if err != nil {
-			f.fs.chargeCredit(req.CreditCharge)
-		}
-	}()
 	if err != nil {
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -1151,7 +1151,7 @@ func (fs *Share) createFile(name string, req *smb2.CreateRequest, followSymlinks
 		return fs.createFileRec(name, req)
 	}
 
-	req.CreditCharge, _, err = fs.loanCredit(0)
+	req.CreditCharge, _, err = fs.borrowCredits(0)
 	if err != nil {
 		return nil, err
 	}
@@ -1175,7 +1175,7 @@ func (fs *Share) createFile(name string, req *smb2.CreateRequest, followSymlinks
 
 func (fs *Share) createFileRec(name string, req *smb2.CreateRequest) (f *File, err error) {
 	for range clientMaxSymlinkDepth {
-		req.CreditCharge, _, err = fs.loanCredit(0)
+		req.CreditCharge, _, err = fs.borrowCredits(0)
 		if err != nil {
 			return nil, err
 		}
@@ -1240,8 +1240,8 @@ func (fs *Share) sendRecv(cmd uint16, req smb2.Packet) (res []byte, err error) {
 	return fs.treeConn.sendRecv(fs.ctx, cmd, req)
 }
 
-func (fs *Share) loanCredit(payloadSize int) (creditCharge uint16, grantedPayloadSize int, err error) {
-	return fs.session.conn.loanCredit(fs.ctx, payloadSize)
+func (fs *Share) borrowCredits(payloadSize int) (creditCharge uint16, grantedPayloadSize int, err error) {
+	return fs.session.conn.borrowCredits(fs.ctx, payloadSize)
 }
 
 type File struct {
@@ -1280,7 +1280,7 @@ func (f *File) close() error {
 	}
 
 	var err error
-	req.CreditCharge, _, err = f.fs.loanCredit(0)
+	req.CreditCharge, _, err = f.fs.borrowCredits(0)
 	if err != nil {
 		return err
 	}
@@ -1446,7 +1446,7 @@ func (f *File) readAt(b []byte, off int64) (n int, err error) {
 }
 
 func (f *File) readAtChunk(n int, off int64) (bs []byte, isEOF bool, rr *requestResponse, err error) {
-	creditCharge, m, err := f.fs.loanCredit(n)
+	creditCharge, m, err := f.fs.borrowCredits(n)
 	if err != nil {
 		return nil, false, nil, err
 	}
@@ -1787,7 +1787,7 @@ func (f *File) Sync() (err error) {
 	req := new(smb2.FlushRequest)
 	req.FileId = f.fd
 
-	req.CreditCharge, _, err = f.fs.loanCredit(0)
+	req.CreditCharge, _, err = f.fs.borrowCredits(0)
 	if err != nil {
 		return &os.PathError{Op: "sync", Path: f.name, Err: err}
 	}
@@ -1954,7 +1954,7 @@ func (f *File) writeAt(b []byte, off int64) (n int, err error) {
 
 // writeAt allows partial write
 func (f *File) writeAtChunk(b []byte, off int64) (n int, err error) {
-	creditCharge, m, err := f.fs.loanCredit(len(b))
+	creditCharge, m, err := f.fs.borrowCredits(len(b))
 	if err != nil {
 		return 0, err
 	}
@@ -2190,7 +2190,7 @@ func (f *File) ioctl(req *smb2.IoctlRequest) (output []byte, err error) {
 		return nil, &InternalError{fmt.Sprintf("payload size %d exceeds max transact size %d", payloadSize, f.maxTransactSize())}
 	}
 
-	req.CreditCharge, _, err = f.fs.loanCredit(payloadSize)
+	req.CreditCharge, _, err = f.fs.borrowCredits(payloadSize)
 	if err != nil {
 		return nil, err
 	}
@@ -2230,7 +2230,7 @@ func (f *File) readdir(pattern string) (fi []os.FileInfo, err error) {
 		return nil, &InternalError{fmt.Sprintf("payload size %d exceeds max transact size %d", payloadSize, f.maxTransactSize())}
 	}
 
-	req.CreditCharge, _, err = f.fs.loanCredit(payloadSize)
+	req.CreditCharge, _, err = f.fs.borrowCredits(payloadSize)
 	if err != nil {
 		return nil, err
 	}
@@ -2289,7 +2289,7 @@ func (f *File) queryInfo(req *smb2.QueryInfoRequest) (infoBytes []byte, err erro
 		return nil, &InternalError{fmt.Sprintf("payload size %d exceeds max transact size %d", payloadSize, f.maxTransactSize())}
 	}
 
-	req.CreditCharge, _, err = f.fs.loanCredit(payloadSize)
+	req.CreditCharge, _, err = f.fs.borrowCredits(payloadSize)
 	if err != nil {
 		return nil, err
 	}
@@ -2356,9 +2356,9 @@ func (f *File) SetSecurityInfoRaw(flags SecurityInformationRequestFlags, sd smb2
 	}
 
 	var err error
-	req.CreditCharge, _, err = f.fs.loanCredit(req.Size())
+	req.CreditCharge, _, err = f.fs.borrowCredits(req.Size())
 	if err != nil {
-		return fmt.Errorf("calling loanCredit: %w", err)
+		return fmt.Errorf("calling borrowCredits: %w", err)
 	}
 
 	_, err = f.sendRecv(smb2.SMB2_SET_INFO, req)
@@ -2376,7 +2376,7 @@ func (f *File) setInfo(req *smb2.SetInfoRequest) (err error) {
 		return &InternalError{fmt.Sprintf("payload size %d exceeds max transact size %d", payloadSize, f.maxTransactSize())}
 	}
 
-	req.CreditCharge, _, err = f.fs.loanCredit(payloadSize)
+	req.CreditCharge, _, err = f.fs.borrowCredits(payloadSize)
 	if err != nil {
 		return err
 	}

--- a/conn.go
+++ b/conn.go
@@ -240,15 +240,8 @@ type requestResponse struct {
 	msgId         uint64
 	asyncId       uint64
 	creditRequest uint16
-	// loan holds the credits borrowed from the account for this request and
-	// doubles as the settlement token. A request is settled exactly once,
-	// either by a response charging the server's grant (tryHandle) or by a
-	// failure refunding the loan. Both call claimLoan, which atomically takes
-	// the amount and leaves zero behind, so the loser's refund becomes a no-op.
-	// This makes the amount self-arbitrating: refund sites charge back
-	// claimLoan() unconditionally. (Whether the receiver or a failure path gets
-	// to settle is still decided by who evicts the request from
-	// outstandingRequests; claimLoan only prevents a second settlement.)
+	// loan is the credits borrowed from the account for this request, and zero
+	// once the request has been settled. Taken via claimLoan.
 	loan    atomic.Uint32
 	pkt     []byte // request packet
 	ctx     context.Context
@@ -353,14 +346,14 @@ type conn struct {
 	useSession atomic.Bool
 }
 
-func (conn *conn) loanCredit(ctx context.Context, payloadSize int) (creditCharge uint16, grantedPayloadSize int, err error) {
+func (conn *conn) borrowCredits(ctx context.Context, payloadSize int) (creditCharge uint16, grantedPayloadSize int, err error) {
 	if conn.capabilities&smb2.SMB2_GLOBAL_CAP_LARGE_MTU == 0 {
 		creditCharge = 1
 	} else {
 		creditCharge = uint16((payloadSize-1)/(64*1024) + 1)
 	}
 
-	creditCharge, isComplete, err := conn.account.loan(ctx, creditCharge)
+	creditCharge, isComplete, err := conn.account.borrow(ctx, creditCharge)
 	if err != nil {
 		return creditCharge, 0, err
 	}
@@ -371,44 +364,42 @@ func (conn *conn) loanCredit(ctx context.Context, payloadSize int) (creditCharge
 	return creditCharge, 64 * 1024 * int(creditCharge), nil
 }
 
-func (conn *conn) chargeCredit(creditCharge uint16) {
-	conn.account.charge(creditCharge, creditCharge)
+func (conn *conn) refundCredits(creditCharge uint16) {
+	conn.account.settle(creditCharge, creditCharge)
 }
 
-// send transmits a control request that did not loan credits from the account
-// (negotiate, session setup, tree connect, echo, ...). loaned is 0, so a
+// send transmits a control request that did not borrow credits from the account
+// (negotiate, session setup, tree connect, echo, ...). borrowed is 0, so a
 // failure refunds nothing.
 func (conn *conn) send(ctx context.Context, req smb2.Packet) (rr *requestResponse, err error) {
 	return conn.sendWith(ctx, req, nil, 0)
 }
 
-// sendWith transmits req. loaned is the number of credits the caller loaned
-// from the account for this request (0 for control requests that do not loan).
-// Before the request is registered no one else can settle it, so a failure
-// refunds loaned directly. Once it is outstanding, settlement is claimLoan's
-// job: the receiver takes the loan when a response charges it (tryHandle), and
-// the post-write failure paths evict the request and charge back whatever loan
-// is left — zero if a response already claimed it.
-func (conn *conn) sendWith(ctx context.Context, req smb2.Packet, tc *treeConn, loaned uint16) (rr *requestResponse, err error) {
+// sendWith transmits req. borrowed is the number of credits drawn from the
+// account for this request, or 0 if none were. On failure it refunds that loan:
+// directly while the request is still unregistered, and afterwards by popping
+// it from outstandingRequests and refunding whatever the loan still holds —
+// zero if a response settled it first.
+func (conn *conn) sendWith(ctx context.Context, req smb2.Packet, tc *treeConn, borrowed uint16) (rr *requestResponse, err error) {
 	conn.m.Lock()
 	defer conn.m.Unlock()
 
 	if conn.err != nil {
-		conn.chargeCredit(loaned)
+		conn.refundCredits(borrowed)
 		return nil, conn.err
 	}
 
 	select {
 	case <-ctx.Done():
-		conn.chargeCredit(loaned)
+		conn.refundCredits(borrowed)
 		return nil, ctx.Err()
 	default:
 		// do nothing
 	}
 
-	rr, err = conn.makeRequestResponse(ctx, req, tc, loaned)
+	rr, err = conn.makeRequestResponse(ctx, req, tc, borrowed)
 	if err != nil {
-		conn.chargeCredit(loaned)
+		conn.refundCredits(borrowed)
 		return nil, err
 	}
 
@@ -418,14 +409,14 @@ func (conn *conn) sendWith(ctx context.Context, req smb2.Packet, tc *treeConn, l
 		case err = <-conn.werr:
 			if err != nil {
 				if _, ok := conn.outstandingRequests.pop(rr.msgId); ok {
-					conn.chargeCredit(rr.claimLoan())
+					conn.refundCredits(rr.claimLoan())
 				}
 
 				return nil, &TransportError{err}
 			}
 		case <-ctx.Done():
 			if _, ok := conn.outstandingRequests.pop(rr.msgId); ok {
-				conn.chargeCredit(rr.claimLoan())
+				conn.refundCredits(rr.claimLoan())
 			}
 
 			return nil, ctx.Err()
@@ -440,7 +431,7 @@ func (conn *conn) sendWith(ctx context.Context, req smb2.Packet, tc *treeConn, l
 			if _, isCancel := req.(*smb2.CancelRequest); !isCancel {
 				conn.sequenceWindow -= uint64(req.Header().CreditCharge)
 			}
-			conn.chargeCredit(rr.claimLoan())
+			conn.refundCredits(rr.claimLoan())
 		}
 
 		return nil, ctx.Err()
@@ -461,26 +452,26 @@ type compoundEntry struct {
 // the sentinel FileId. Returns one requestResponse per entry for receiving
 // individual responses.
 //
-// Caller must have already set CreditCharge on each entry's header (via loanCredit).
+// Caller must have already set CreditCharge on each entry's header (via borrowCredits).
 func (conn *conn) sendCompound(ctx context.Context, entries []compoundEntry) ([]*requestResponse, error) {
 	conn.m.Lock()
 	defer conn.m.Unlock()
 
-	// Total credits the caller loaned for this batch; refunded if the batch
+	// Total credits the caller borrowed for this batch; refunded if the batch
 	// fails before any response can settle it.
-	var totalLoaned uint16
+	var totalBorrowed uint16
 	for _, entry := range entries {
-		totalLoaned += entry.req.Header().CreditCharge
+		totalBorrowed += entry.req.Header().CreditCharge
 	}
 
 	if conn.err != nil {
-		conn.chargeCredit(totalLoaned)
+		conn.refundCredits(totalBorrowed)
 		return nil, conn.err
 	}
 
 	select {
 	case <-ctx.Done():
-		conn.chargeCredit(totalLoaned)
+		conn.refundCredits(totalBorrowed)
 		return nil, ctx.Err()
 	default:
 	}
@@ -591,7 +582,7 @@ func (conn *conn) sendCompound(ctx context.Context, entries []compoundEntry) ([]
 				// total alongside the credit refund. (Compounds never carry
 				// CancelRequests, so no per-entry guard is needed.)
 				conn.sequenceWindow -= uint64(totalCreditCharge)
-				conn.chargeCredit(totalLoaned)
+				conn.refundCredits(totalBorrowed)
 				return nil, &InternalError{err.Error()}
 			}
 		} else if s.sessionFlags&(smb2.SMB2_SESSION_FLAG_IS_GUEST|smb2.SMB2_SESSION_FLAG_IS_NULL) == 0 {
@@ -662,16 +653,16 @@ func (conn *conn) sendCompound(ctx context.Context, entries []compoundEntry) ([]
 
 // refundCompound pops each request that never left, refunding its loan. Popping
 // is what serializes against the receiver: if a response already settled a
-// request (pop fails), its credits were charged back there instead.
+// request (pop fails), its credits were refunded there instead.
 func (conn *conn) refundCompound(rrs []*requestResponse) {
 	for _, rr := range rrs {
 		if _, ok := conn.outstandingRequests.pop(rr.msgId); ok {
-			conn.chargeCredit(rr.claimLoan())
+			conn.refundCredits(rr.claimLoan())
 		}
 	}
 }
 
-func (conn *conn) makeRequestResponse(ctx context.Context, req smb2.Packet, tc *treeConn, loaned uint16) (rr *requestResponse, err error) {
+func (conn *conn) makeRequestResponse(ctx context.Context, req smb2.Packet, tc *treeConn, borrowed uint16) (rr *requestResponse, err error) {
 	hdr := req.Header()
 
 	var msgId uint64
@@ -722,8 +713,8 @@ func (conn *conn) makeRequestResponse(ctx context.Context, req smb2.Packet, tc *
 					// The packet never reached the writer and conn.m has been
 					// held since allocation, so no later ID exists: give the
 					// window slot back. Guarded like the advance above, since a
-					// CancelRequest never took one. Our caller (sendWith)
-					// refunds the loan, so credits and window are both restored.
+					// CancelRequest never took one. The caller should refund the
+					// loan, so credits and window are both restored.
 					if _, ok := req.(*smb2.CancelRequest); !ok {
 						conn.sequenceWindow -= uint64(hdr.CreditCharge)
 					}
@@ -744,7 +735,7 @@ func (conn *conn) makeRequestResponse(ctx context.Context, req smb2.Packet, tc *
 		ctx:           ctx,
 		recv:          make(chan []byte, 1),
 	}
-	rr.loan.Store(uint32(loaned))
+	rr.loan.Store(uint32(borrowed))
 
 	conn.outstandingRequests.set(msgId, rr)
 
@@ -756,20 +747,20 @@ func (conn *conn) recv(rr *requestResponse) ([]byte, error) {
 	case pkt := <-rr.recv:
 		if rr.err != nil {
 			// Transport shutdown: outstandingRequests.shutdown sets rr.err and
-			// closes recv without evicting the request, so no one has settled
+			// closes recv without popping the request, so no one has settled
 			// the loan. (A response that failed verification settles it in
 			// tryHandle instead, and claiming again here yields zero.)
-			conn.chargeCredit(rr.claimLoan())
+			conn.refundCredits(rr.claimLoan())
 			return nil, rr.err
 		}
 		return pkt, nil
 	case <-rr.ctx.Done():
 		// Refund only if we win the race to remove the request: if the pop
-		// fails, the receiver already took the request and is charging its
+		// fails, the receiver already took the request and is settling its
 		// response. claimLoan then yields the loan to refund (zero if an
 		// interim response already claimed it).
 		if _, ok := conn.outstandingRequests.pop(rr.msgId); ok {
-			conn.chargeCredit(rr.claimLoan())
+			conn.refundCredits(rr.claimLoan())
 		}
 
 		return nil, rr.ctx.Err()
@@ -1117,24 +1108,22 @@ func (conn *conn) tryHandle(pkt []byte, e error, rb *recvBuf) error {
 		return &InvalidResponseError{"unknown message id returned"}
 	case e != nil:
 		rr.err = e
-		// We evicted the request, so we own its settlement. Refunding here
-		// rather than leaving it to conn.recv matters when rr.ctx is already
-		// done: both of that select's arms would be ready, and if it takes the
-		// ctx arm the pop fails and nothing refunds the loan.
-		conn.chargeCredit(rr.claimLoan())
+		// The pop above took the request, so nothing else can settle it:
+		// refund the loan here.
+		conn.refundCredits(rr.claimLoan())
 		conn.freePoolBuf(rb)
 
 		close(rr.recv)
 	case erref.NtStatus(p.Status()) == erref.STATUS_PENDING:
 		rr.asyncId = p.AsyncId()
-		conn.account.charge(p.CreditResponse(), rr.creditRequest)
+		conn.account.settle(p.CreditResponse(), rr.creditRequest)
 		// The response settled the loan; take it so the re-registered request
 		// is not refunded again if the caller later abandons it.
 		rr.claimLoan()
 		conn.outstandingRequests.set(msgId, rr)
 		conn.freePoolBuf(rb)
 	default:
-		conn.account.charge(p.CreditResponse(), rr.creditRequest)
+		conn.account.settle(p.CreditResponse(), rr.creditRequest)
 		rr.claimLoan()
 
 		// Transfer ownership of the pooled receive buffer to the

--- a/conn.go
+++ b/conn.go
@@ -431,7 +431,15 @@ func (conn *conn) sendWith(ctx context.Context, req smb2.Packet, tc *treeConn, l
 			return nil, ctx.Err()
 		}
 	case <-ctx.Done():
+		// Outer arm: the packet never reached the writer. conn.m has been held
+		// since allocation, so no later ID exists and this slot can be reused;
+		// roll the window back alongside the loan refund. Skipped for a
+		// CancelRequest, which never advanced the window. The two inner arms
+		// above must NOT do this: there the packet may already be on the wire.
 		if _, ok := conn.outstandingRequests.pop(rr.msgId); ok {
+			if _, isCancel := req.(*smb2.CancelRequest); !isCancel {
+				conn.sequenceWindow -= uint64(req.Header().CreditCharge)
+			}
 			conn.chargeCredit(rr.claimLoan())
 		}
 
@@ -577,6 +585,12 @@ func (conn *conn) sendCompound(ctx context.Context, entries []compoundEntry) ([]
 			var err error
 			wirePkt, err = s.encrypt(compound, s.encryptBuf[:needed])
 			if err != nil {
+				// The frame never reached the writer and conn.m has been held
+				// since the window was advanced in phase 1, so the whole
+				// batch's slots can be reused. Roll the window back by the batch
+				// total alongside the credit refund. (Compounds never carry
+				// CancelRequests, so no per-entry guard is needed.)
+				conn.sequenceWindow -= uint64(totalCreditCharge)
 				conn.chargeCredit(totalLoaned)
 				return nil, &InternalError{err.Error()}
 			}
@@ -632,6 +646,13 @@ func (conn *conn) sendCompound(ctx context.Context, entries []compoundEntry) ([]
 			return nil, ctx.Err()
 		}
 	case <-ctx.Done():
+		// Outer arm: the frame never reached the writer. conn.m has been held
+		// since phase 1, so the whole batch's slots can be reused; roll the
+		// window back by the batch total alongside refundCompound. The two inner
+		// arms above must NOT do this, and refundCompound is shared with them:
+		// there the frame may already be on the wire, so only the credits (not
+		// the window) may be returned.
+		conn.sequenceWindow -= uint64(totalCreditCharge)
 		conn.refundCompound(rrs)
 		return nil, ctx.Err()
 	}
@@ -698,6 +719,14 @@ func (conn *conn) makeRequestResponse(ctx context.Context, req smb2.Packet, tc *
 				clear(s.encryptBuf[:needed])
 				pkt, err = s.encrypt(pkt, s.encryptBuf[:needed])
 				if err != nil {
+					// The packet never reached the writer and conn.m has been
+					// held since allocation, so no later ID exists: give the
+					// window slot back. Guarded like the advance above, since a
+					// CancelRequest never took one. Our caller (sendWith)
+					// refunds the loan, so credits and window are both restored.
+					if _, ok := req.(*smb2.CancelRequest); !ok {
+						conn.sequenceWindow -= uint64(hdr.CreditCharge)
+					}
 					return nil, &InternalError{err.Error()}
 				}
 			} else {

--- a/conn.go
+++ b/conn.go
@@ -240,12 +240,29 @@ type requestResponse struct {
 	msgId         uint64
 	asyncId       uint64
 	creditRequest uint16
-	pkt           []byte // request packet
-	ctx           context.Context
-	recv          chan []byte
-	err           error
-	rb            *recvBuf   // pooled receive buffer wrapper; return via freeRecvBuf
-	bufPool       *sync.Pool // pool to return rb to
+	// loan holds the credits borrowed from the account for this request and
+	// doubles as the settlement token. A request is settled exactly once,
+	// either by a response charging the server's grant (tryHandle) or by a
+	// failure refunding the loan. Both call claimLoan, which atomically takes
+	// the amount and leaves zero behind, so the loser's refund becomes a no-op.
+	// This makes the amount self-arbitrating: refund sites charge back
+	// claimLoan() unconditionally. (Whether the receiver or a failure path gets
+	// to settle is still decided by who evicts the request from
+	// outstandingRequests; claimLoan only prevents a second settlement.)
+	loan    atomic.Uint32
+	pkt     []byte // request packet
+	ctx     context.Context
+	recv    chan []byte
+	err     error
+	rb      *recvBuf   // pooled receive buffer wrapper; return via freeRecvBuf
+	bufPool *sync.Pool // pool to return rb to
+}
+
+// claimLoan atomically takes the request's outstanding loan, returning the
+// credits to refund — zero if a response, or an earlier settlement, already
+// took it. Safe from any goroutine; only the first caller gets a nonzero value.
+func (rr *requestResponse) claimLoan() uint16 {
+	return uint16(rr.loan.Swap(0))
 }
 
 // freeRecvBuf returns the pooled receive buffer, if any. Safe to call
@@ -358,27 +375,40 @@ func (conn *conn) chargeCredit(creditCharge uint16) {
 	conn.account.charge(creditCharge, creditCharge)
 }
 
+// send transmits a control request that did not loan credits from the account
+// (negotiate, session setup, tree connect, echo, ...). loaned is 0, so a
+// failure refunds nothing.
 func (conn *conn) send(ctx context.Context, req smb2.Packet) (rr *requestResponse, err error) {
-	return conn.sendWith(ctx, req, nil)
+	return conn.sendWith(ctx, req, nil, 0)
 }
 
-func (conn *conn) sendWith(ctx context.Context, req smb2.Packet, tc *treeConn) (rr *requestResponse, err error) {
+// sendWith transmits req. loaned is the number of credits the caller loaned
+// from the account for this request (0 for control requests that do not loan).
+// Before the request is registered no one else can settle it, so a failure
+// refunds loaned directly. Once it is outstanding, settlement is claimLoan's
+// job: the receiver takes the loan when a response charges it (tryHandle), and
+// the post-write failure paths evict the request and charge back whatever loan
+// is left — zero if a response already claimed it.
+func (conn *conn) sendWith(ctx context.Context, req smb2.Packet, tc *treeConn, loaned uint16) (rr *requestResponse, err error) {
 	conn.m.Lock()
 	defer conn.m.Unlock()
 
 	if conn.err != nil {
+		conn.chargeCredit(loaned)
 		return nil, conn.err
 	}
 
 	select {
 	case <-ctx.Done():
+		conn.chargeCredit(loaned)
 		return nil, ctx.Err()
 	default:
 		// do nothing
 	}
 
-	rr, err = conn.makeRequestResponse(ctx, req, tc)
+	rr, err = conn.makeRequestResponse(ctx, req, tc, loaned)
 	if err != nil {
+		conn.chargeCredit(loaned)
 		return nil, err
 	}
 
@@ -387,17 +417,23 @@ func (conn *conn) sendWith(ctx context.Context, req smb2.Packet, tc *treeConn) (
 		select {
 		case err = <-conn.werr:
 			if err != nil {
-				conn.outstandingRequests.pop(rr.msgId)
+				if _, ok := conn.outstandingRequests.pop(rr.msgId); ok {
+					conn.chargeCredit(rr.claimLoan())
+				}
 
 				return nil, &TransportError{err}
 			}
 		case <-ctx.Done():
-			conn.outstandingRequests.pop(rr.msgId)
+			if _, ok := conn.outstandingRequests.pop(rr.msgId); ok {
+				conn.chargeCredit(rr.claimLoan())
+			}
 
 			return nil, ctx.Err()
 		}
 	case <-ctx.Done():
-		conn.outstandingRequests.pop(rr.msgId)
+		if _, ok := conn.outstandingRequests.pop(rr.msgId); ok {
+			conn.chargeCredit(rr.claimLoan())
+		}
 
 		return nil, ctx.Err()
 	}
@@ -422,12 +458,21 @@ func (conn *conn) sendCompound(ctx context.Context, entries []compoundEntry) ([]
 	conn.m.Lock()
 	defer conn.m.Unlock()
 
+	// Total credits the caller loaned for this batch; refunded if the batch
+	// fails before any response can settle it.
+	var totalLoaned uint16
+	for _, entry := range entries {
+		totalLoaned += entry.req.Header().CreditCharge
+	}
+
 	if conn.err != nil {
+		conn.chargeCredit(totalLoaned)
 		return nil, conn.err
 	}
 
 	select {
 	case <-ctx.Done():
+		conn.chargeCredit(totalLoaned)
 		return nil, ctx.Err()
 	default:
 	}
@@ -532,6 +577,7 @@ func (conn *conn) sendCompound(ctx context.Context, entries []compoundEntry) ([]
 			var err error
 			wirePkt, err = s.encrypt(compound, s.encryptBuf[:needed])
 			if err != nil {
+				conn.chargeCredit(totalLoaned)
 				return nil, &InternalError{err.Error()}
 			}
 		} else if s.sessionFlags&(smb2.SMB2_SESSION_FLAG_IS_GUEST|smb2.SMB2_SESSION_FLAG_IS_NULL) == 0 {
@@ -563,6 +609,7 @@ func (conn *conn) sendCompound(ctx context.Context, entries []compoundEntry) ([]
 			ctx:           ctx,
 			recv:          make(chan []byte, 1),
 		}
+		rrs[i].loan.Store(uint32(p.CreditCharge()))
 		conn.outstandingRequests.set(rrs[i].msgId, rrs[i])
 
 		if i < n-1 {
@@ -577,28 +624,33 @@ func (conn *conn) sendCompound(ctx context.Context, entries []compoundEntry) ([]
 		select {
 		case err := <-conn.werr:
 			if err != nil {
-				for _, rr := range rrs {
-					conn.outstandingRequests.pop(rr.msgId)
-				}
+				conn.refundCompound(rrs)
 				return nil, &TransportError{err}
 			}
 		case <-ctx.Done():
-			for _, rr := range rrs {
-				conn.outstandingRequests.pop(rr.msgId)
-			}
+			conn.refundCompound(rrs)
 			return nil, ctx.Err()
 		}
 	case <-ctx.Done():
-		for _, rr := range rrs {
-			conn.outstandingRequests.pop(rr.msgId)
-		}
+		conn.refundCompound(rrs)
 		return nil, ctx.Err()
 	}
 
 	return rrs, nil
 }
 
-func (conn *conn) makeRequestResponse(ctx context.Context, req smb2.Packet, tc *treeConn) (rr *requestResponse, err error) {
+// refundCompound pops each request that never left, refunding its loan. Popping
+// is what serializes against the receiver: if a response already settled a
+// request (pop fails), its credits were charged back there instead.
+func (conn *conn) refundCompound(rrs []*requestResponse) {
+	for _, rr := range rrs {
+		if _, ok := conn.outstandingRequests.pop(rr.msgId); ok {
+			conn.chargeCredit(rr.claimLoan())
+		}
+	}
+}
+
+func (conn *conn) makeRequestResponse(ctx context.Context, req smb2.Packet, tc *treeConn, loaned uint16) (rr *requestResponse, err error) {
 	hdr := req.Header()
 
 	var msgId uint64
@@ -663,6 +715,7 @@ func (conn *conn) makeRequestResponse(ctx context.Context, req smb2.Packet, tc *
 		ctx:           ctx,
 		recv:          make(chan []byte, 1),
 	}
+	rr.loan.Store(uint32(loaned))
 
 	conn.outstandingRequests.set(msgId, rr)
 
@@ -673,11 +726,22 @@ func (conn *conn) recv(rr *requestResponse) ([]byte, error) {
 	select {
 	case pkt := <-rr.recv:
 		if rr.err != nil {
+			// Transport shutdown: outstandingRequests.shutdown sets rr.err and
+			// closes recv without evicting the request, so no one has settled
+			// the loan. (A response that failed verification settles it in
+			// tryHandle instead, and claiming again here yields zero.)
+			conn.chargeCredit(rr.claimLoan())
 			return nil, rr.err
 		}
 		return pkt, nil
 	case <-rr.ctx.Done():
-		conn.outstandingRequests.pop(rr.msgId)
+		// Refund only if we win the race to remove the request: if the pop
+		// fails, the receiver already took the request and is charging its
+		// response. claimLoan then yields the loan to refund (zero if an
+		// interim response already claimed it).
+		if _, ok := conn.outstandingRequests.pop(rr.msgId); ok {
+			conn.chargeCredit(rr.claimLoan())
+		}
 
 		return nil, rr.ctx.Err()
 	}
@@ -1024,16 +1088,25 @@ func (conn *conn) tryHandle(pkt []byte, e error, rb *recvBuf) error {
 		return &InvalidResponseError{"unknown message id returned"}
 	case e != nil:
 		rr.err = e
+		// We evicted the request, so we own its settlement. Refunding here
+		// rather than leaving it to conn.recv matters when rr.ctx is already
+		// done: both of that select's arms would be ready, and if it takes the
+		// ctx arm the pop fails and nothing refunds the loan.
+		conn.chargeCredit(rr.claimLoan())
 		conn.freePoolBuf(rb)
 
 		close(rr.recv)
 	case erref.NtStatus(p.Status()) == erref.STATUS_PENDING:
 		rr.asyncId = p.AsyncId()
 		conn.account.charge(p.CreditResponse(), rr.creditRequest)
+		// The response settled the loan; take it so the re-registered request
+		// is not refunded again if the caller later abandons it.
+		rr.claimLoan()
 		conn.outstandingRequests.set(msgId, rr)
 		conn.freePoolBuf(rb)
 	default:
 		conn.account.charge(p.CreditResponse(), rr.creditRequest)
+		rr.claimLoan()
 
 		// Transfer ownership of the pooled receive buffer to the
 		// requestResponse so the caller can return it via freeRecvBuf

--- a/credit.go
+++ b/credit.go
@@ -25,7 +25,7 @@ func (a *account) initRequest() uint16 {
 	return uint16(cap(a.balance) - len(a.balance))
 }
 
-func (a *account) loan(ctx context.Context, creditCharge uint16) (uint16, bool, error) {
+func (a *account) borrow(ctx context.Context, creditCharge uint16) (uint16, bool, error) {
 	select {
 	case <-a.balance:
 	case <-ctx.Done():
@@ -54,7 +54,7 @@ func (a *account) opening() uint16 {
 	return ret
 }
 
-func (a *account) charge(granted, requested uint16) {
+func (a *account) settle(granted, requested uint16) {
 	if granted == 0 && requested == 0 {
 		return
 	}

--- a/credit_books_test.go
+++ b/credit_books_test.go
@@ -1,0 +1,292 @@
+package smb2
+
+// Regression test for double-settlement of credits on error-status responses.
+//
+// The defect: tryHandle banks the server's CreditResponse for every non-pending
+// response, and the old per-operation `defer { if err != nil { chargeCredit } }`
+// in client.go then refunded the loan a second time because accept() turned the
+// error status into a Go error. The client's balance drifted +CreditCharge
+// ahead of the server's command sequence window per failed operation; concurrent
+// callers draining the inflated balance overran the window, and a real server
+// answers STATUS_INVALID_PARAMETER or drops the connection (MS-SMB2 3.3.5.2.3).
+//
+// The fix makes credit settlement single-owner: a response settles the loan
+// (tryHandle marks it accounted), and the loan is refunded only when no response
+// ever settled it. Both subtests must show zero fabricated credits and zero
+// window violations regardless of whether operations fail.
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudsoda/go-smb2/internal/erref"
+	"github.com/cloudsoda/go-smb2/internal/smb2"
+)
+
+// Reads at this offset are answered with STATUS_OBJECT_NAME_NOT_FOUND.
+const errorOffset = 0xEE00
+
+// Nonzero so session.recv's IBM-iSeries session-id adoption path (an
+// unsynchronized write to s.sessionId when it is 0) stays out of the way.
+const booksSessionId = 0xb00c5
+
+type bookedResponse struct {
+	msgId  uint64
+	cc     uint16
+	status uint32
+}
+
+// creditBooksServer is a fake server that keeps honest credit books: grants
+// are counted when a response is written (that is when the client can first
+// use them), consumption when a request arrives, and any request whose
+// [MessageId, MessageId+CreditCharge) range exceeds total granted credits is
+// recorded as a sequence-window violation — the check a real server enforces
+// with STATUS_INVALID_PARAMETER / disconnect.
+type creditBooksServer struct {
+	t transport
+
+	mu        sync.Mutex
+	granted   uint64 // total credits ever granted, incl. the initial credit
+	consumed  uint64 // total CreditCharge received
+	firstDone bool
+
+	violations atomic.Int64
+	respDelay  atomic.Int64 // per-response delay in ns; lets in-flight pile up
+	queue      chan bookedResponse
+}
+
+func newCreditBooksServer(t transport) *creditBooksServer {
+	return &creditBooksServer{t: t, granted: 1, queue: make(chan bookedResponse, 1024)}
+}
+
+// outstanding is the number of credits the server believes the client holds.
+func (s *creditBooksServer) outstanding() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.granted - s.consumed
+}
+
+func (s *creditBooksServer) run() {
+	go s.respond()
+
+	buf := make([]byte, bufSize)
+	for {
+		n, err := s.t.ReadSize()
+		if err != nil {
+			close(s.queue)
+			return
+		}
+		if _, err := s.t.Read(buf[:n]); err != nil {
+			close(s.queue)
+			return
+		}
+
+		p := smb2.PacketCodec(buf[:n])
+		msgId := p.MessageId()
+		cc := p.CreditCharge()
+		if cc == 0 {
+			cc = 1
+		}
+
+		s.mu.Lock()
+		if msgId+uint64(cc) > s.granted {
+			s.violations.Add(1)
+		}
+		s.consumed += uint64(cc)
+		s.mu.Unlock()
+
+		status := uint32(erref.STATUS_SUCCESS)
+		if binary.LittleEndian.Uint64(buf[72:80]) == errorOffset { // ReadRequest.Offset
+			status = uint32(erref.STATUS_OBJECT_NAME_NOT_FOUND)
+		}
+
+		s.queue <- bookedResponse{msgId: msgId, cc: cc, status: status}
+	}
+}
+
+func (s *creditBooksServer) respond() {
+	resp := &smb2.ReadResponse{
+		PacketHeader: smb2.PacketHeader{
+			Flags:     smb2.SMB2_FLAGS_SERVER_TO_REDIR,
+			SessionId: booksSessionId,
+		},
+		Data: make([]byte, 8),
+	}
+	respBuf := make([]byte, resp.Size())
+	resp.Encode(respBuf)
+	respBuf[64+2] = 80 // DataOffset from packet start
+	rp := smb2.PacketCodec(respBuf)
+	rp.SetCommand(smb2.SMB2_READ)
+
+	for br := range s.queue {
+		if d := s.respDelay.Load(); d > 0 {
+			time.Sleep(time.Duration(d))
+		}
+
+		// Replacement-only grant policy (a conservative/loaded server),
+		// plus a one-time window build-up like a session-setup grant.
+		g := br.cc
+		s.mu.Lock()
+		if !s.firstDone {
+			s.firstDone = true
+			g += 31
+		}
+		s.granted += uint64(g)
+		s.mu.Unlock()
+
+		rp.SetMessageId(br.msgId)
+		rp.SetCreditResponse(g)
+		rp.SetStatus(br.status)
+
+		if _, err := s.t.Write(respBuf); err != nil {
+			return
+		}
+	}
+}
+
+func TestCreditDoubleSettlement(t *testing.T) {
+	t.Run("control", func(t *testing.T) { runCreditBooks(t, false) })
+	t.Run("error-responses", func(t *testing.T) { runCreditBooks(t, true) })
+}
+
+func runCreditBooks(t *testing.T, injectErrors bool) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	clientConn, serverConn := net.Pipe()
+	c, cleanup := newBenchConn(clientConn)
+	defer cleanup()
+
+	c.session.Store(&session{
+		conn:         c,
+		sessionFlags: smb2.SMB2_SESSION_FLAG_IS_GUEST,
+		sessionId:    booksSessionId,
+	})
+
+	srv := newCreditBooksServer(direct(serverConn))
+	go srv.run()
+
+	f := newBenchFile(c)
+	buf := make([]byte, 8)
+
+	// Phase A: successful reads — books must stay balanced.
+	for range 20 {
+		_, err := f.readAt(buf, 0)
+		require.NoError(err)
+	}
+
+	// Phase B: operations that fail with an error-status response.
+	const K = 24
+	if injectErrors {
+		for range K {
+			_, err := f.readAt(buf, errorOffset)
+			require.Error(err, "expected error from read at errorOffset")
+		}
+	}
+
+	// Phase B2: CLOSE consumes a window slot like any other file operation, so
+	// it must loan too. (The fake server answers everything with a READ-shaped
+	// response, so close reports a decode error; what is under test here is the
+	// books, not the reply.)
+	for range 5 {
+		f.close()
+	}
+
+	// Books check. Everything above is sequential and settled.
+	clientCredits := int64(len(c.account.balance))
+	serverCredits := int64(srv.outstanding())
+	fabricated := clientCredits - serverCredits
+	t.Logf("client balance=%d server outstanding=%d fabricated=%+d",
+		clientCredits, serverCredits, fabricated)
+
+	// With single-owner settlement, error-status responses no longer fabricate
+	// credits: the balance must track the server's outstanding grant exactly,
+	// whether or not operations failed.
+	assert.Zero(fabricated, "books diverged (injectErrors=%v): client=%d server=%d",
+		injectErrors, clientCredits, serverCredits)
+
+	// Phase C: concurrent burst of multi-credit reads while responses are
+	// delayed. With honest books in-flight credits can never exceed the
+	// server's window; fabricated credits let the client overrun it.
+	srv.respDelay.Store(int64(2 * time.Millisecond))
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			big := make([]byte, 512*1024)
+			for range 3 {
+				f.readAt(big, 0)
+			}
+		})
+	}
+	wg.Wait()
+
+	v := srv.violations.Load()
+	t.Logf("sequence-window violations during burst: %d", v)
+	assert.Zero(v, "client overran the server's sequence window %d times (injectErrors=%v)", v, injectErrors)
+}
+
+// TestTryHandleRefundsLoanOnFailedVerification covers the other half of the
+// single-owner rule: a response that fails verification (bad signature, decode
+// error) evicts the request but is not a settlement, so tryHandle must refund
+// the loan itself.
+//
+// Leaving that refund to conn.recv leaks credits when the caller's context is
+// already done: recv's select then has both arms ready, and on the ctx arm the
+// pop fails — tryHandle already took the request — so nothing charges the loan
+// back. The leak is permanent, so a connection that keeps hitting it eventually
+// starves and every operation blocks in account.loan.
+//
+// Each round below uses a cancelled context, making that select a coin flip;
+// repeating makes taking the leaky arm at least once a near-certainty.
+func TestTryHandleRefundsLoanOnFailedVerification(t *testing.T) {
+	require := require.New(t)
+
+	c := &conn{
+		outstandingRequests: newOutstandingRequests(),
+		account:             openAccount(128),
+	}
+
+	// Open the account up to 9 credits. Each round borrows and must return 2.
+	c.account.charge(8, 8)
+	const want = 9
+	require.Equal(want, len(c.account.balance))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	verifyErr := &InvalidResponseError{"packet failed signature verification"}
+
+	for round := range 50 {
+		loaned, _, err := c.account.loan(context.Background(), 2)
+		require.NoError(err)
+		require.EqualValues(2, loaned)
+
+		msgId := uint64(round)
+		rr := &requestResponse{msgId: msgId, ctx: ctx, recv: make(chan []byte, 1)}
+		rr.loan.Store(uint32(loaned))
+		c.outstandingRequests.set(msgId, rr)
+
+		// A response arrives for this request but fails verification.
+		pkt := make([]byte, 64)
+		smb2.PacketCodec(pkt).SetMessageId(msgId)
+		require.NoError(c.tryHandle(pkt, verifyErr, nil))
+
+		require.Equal(want, len(c.account.balance),
+			"round %d: loan must be refunded when the response is not a settlement", round)
+
+		// The caller then observes the failure down whichever arm of recv's
+		// select wins. The loan is already claimed, so neither refunds twice.
+		_, err = c.recv(rr)
+		require.Error(err)
+		require.Equal(want, len(c.account.balance),
+			"round %d: loan must not be refunded twice", round)
+	}
+}

--- a/credit_books_test.go
+++ b/credit_books_test.go
@@ -1,19 +1,16 @@
 package smb2
 
-// Regression test for double-settlement of credits on error-status responses.
+// Credit-accounting tests driven against a fake server that keeps its own books.
 //
-// The defect: tryHandle banks the server's CreditResponse for every non-pending
-// response, and the old per-operation `defer { if err != nil { chargeCredit } }`
-// in client.go then refunded the loan a second time because accept() turned the
-// error status into a Go error. The client's balance drifted +CreditCharge
-// ahead of the server's command sequence window per failed operation; concurrent
-// callers draining the inflated balance overran the window, and a real server
-// answers STATUS_INVALID_PARAMETER or drops the connection (MS-SMB2 3.3.5.2.3).
+// The invariant under test is that the client's spendable balance never exceeds
+// what the server has granted. A client holding credits the server never issued
+// will address message IDs past the server's command sequence window, which a
+// real server answers with STATUS_INVALID_PARAMETER or a disconnect
+// (MS-SMB2 3.3.5.2.3).
 //
-// The fix makes credit settlement single-owner: a response settles the loan
-// (tryHandle marks it accounted), and the loan is refunded only when no response
-// ever settled it. Both subtests must show zero fabricated credits and zero
-// window violations regardless of whether operations fail.
+// Settlement has exactly one owner per request: a response settles the loan when
+// tryHandle banks the server's grant, and otherwise the loan is refunded. The two
+// tests here pin one half of that rule each.
 
 import (
 	"context"
@@ -193,7 +190,7 @@ func runCreditBooks(t *testing.T, injectErrors bool) {
 	}
 
 	// Phase B2: CLOSE consumes a window slot like any other file operation, so
-	// it must loan too. (The fake server answers everything with a READ-shaped
+	// it must borrow too. (The fake server answers everything with a READ-shaped
 	// response, so close reports a decode error; what is under test here is the
 	// books, not the reply.)
 	for range 5 {
@@ -235,17 +232,17 @@ func runCreditBooks(t *testing.T, injectErrors bool) {
 
 // TestTryHandleRefundsLoanOnFailedVerification covers the other half of the
 // single-owner rule: a response that fails verification (bad signature, decode
-// error) evicts the request but is not a settlement, so tryHandle must refund
+// error) pops the request but is not a settlement, so tryHandle must refund
 // the loan itself.
 //
-// Leaving that refund to conn.recv leaks credits when the caller's context is
-// already done: recv's select then has both arms ready, and on the ctx arm the
-// pop fails — tryHandle already took the request — so nothing charges the loan
-// back. The leak is permanent, so a connection that keeps hitting it eventually
-// starves and every operation blocks in account.loan.
+// Leaving that refund to conn.recv would leak the loan whenever the caller's
+// context is already done, because recv can then return by the context path,
+// where the request has already been popped and nothing refunds. The leak is
+// permanent, so a connection that keeps hitting it eventually starves and every
+// operation blocks in account.borrow.
 //
-// Each round below uses a cancelled context, making that select a coin flip;
-// repeating makes taking the leaky arm at least once a near-certainty.
+// Each round below uses a cancelled context, so which path recv returns by is
+// unpredictable; 50 rounds make hitting the leaky one a near-certainty.
 func TestTryHandleRefundsLoanOnFailedVerification(t *testing.T) {
 	require := require.New(t)
 
@@ -255,7 +252,7 @@ func TestTryHandleRefundsLoanOnFailedVerification(t *testing.T) {
 	}
 
 	// Open the account up to 9 credits. Each round borrows and must return 2.
-	c.account.charge(8, 8)
+	c.account.settle(8, 8)
 	const want = 9
 	require.Equal(want, len(c.account.balance))
 
@@ -265,13 +262,13 @@ func TestTryHandleRefundsLoanOnFailedVerification(t *testing.T) {
 	verifyErr := &InvalidResponseError{"packet failed signature verification"}
 
 	for round := range 50 {
-		loaned, _, err := c.account.loan(context.Background(), 2)
+		borrowed, _, err := c.account.borrow(context.Background(), 2)
 		require.NoError(err)
-		require.EqualValues(2, loaned)
+		require.EqualValues(2, borrowed)
 
 		msgId := uint64(round)
 		rr := &requestResponse{msgId: msgId, ctx: ctx, recv: make(chan []byte, 1)}
-		rr.loan.Store(uint32(loaned))
+		rr.loan.Store(uint32(borrowed))
 		c.outstandingRequests.set(msgId, rr)
 
 		// A response arrives for this request but fails verification.
@@ -282,8 +279,8 @@ func TestTryHandleRefundsLoanOnFailedVerification(t *testing.T) {
 		require.Equal(want, len(c.account.balance),
 			"round %d: loan must be refunded when the response is not a settlement", round)
 
-		// The caller then observes the failure down whichever arm of recv's
-		// select wins. The loan is already claimed, so neither refunds twice.
+		// The caller then observes the failure, by whichever path recv returns.
+		// The loan is already claimed, so neither path refunds twice.
 		_, err = c.recv(rr)
 		require.Error(err)
 		require.Equal(want, len(c.account.balance),

--- a/credit_refund_test.go
+++ b/credit_refund_test.go
@@ -1,17 +1,31 @@
 package smb2
 
-// White-box tests hardening the single-owner credit settlement rule introduced
-// by the double-settlement fix: each requestResponse carries its loan in an
-// atomic; claimLoan swap-takes it exactly once, so whichever of the receiver or
-// a failure path evicts the request settles the loan, and the loser's refund
-// becomes a no-op charge of zero. The paths covered here — tryHandle's
-// STATUS_PENDING arm and recv's two refund arms with a nonzero, unclaimed
-// loan — were previously untested.
+// White-box tests for the credit refund/settlement paths in conn.go.
+//
+// Two invariants are under test:
+//
+//  1. The window/credit invariant (SEQUENCE-ROLLBACK.md): after any send that
+//     fails before the packet reaches the writer, conn.sequenceWindow (the next
+//     message ID the client will allocate) plus len(conn.account.balance) (the
+//     spendable credit count) must equal the server's window ceiling. A send that
+//     allocates a message ID but never transmits it must roll the window back, or
+//     the client's ID counter drifts ahead of what its balance can address.
+//
+//  2. Single-owner settlement (commit 62dc3c9): each requestResponse carries its
+//     loan in an atomic; claimLoan swap-takes it exactly once, so whichever of the
+//     receiver or a failure path evicts the request settles the loan, and the
+//     loser's refund becomes a no-op charge of zero.
+//
+// TestSendWith... and TestSendCompound... are regression tests for invariant 1:
+// before the rollback fix, their sequenceWindow assertions failed (the window
+// stayed advanced at 3 and 7) while the refund assertions passed.
+// TestPendingResponseSettlesLoanOnce and TestRecvRefundsLoan pin invariant 2.
 
 import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -23,11 +37,239 @@ import (
 // up from its initial single credit.
 const startBalance = 9
 
+// newRollbackConn builds a conn with no sender/receiver goroutines, matching the
+// negotiated parameters of a typical SMB 3.0.2 large-MTU connection. No session
+// is stored, so the encode paths skip signing and encryption. sequenceWindow
+// starts at 1 (the first message ID a real client allocates), and the account is
+// opened up to startBalance spendable credits.
+func newRollbackConn() *conn {
+	c := &conn{
+		outstandingRequests: newOutstandingRequests(),
+		account:             openAccount(128),
+		write:               make(chan []byte, 1),
+		werr:                make(chan error, 1),
+		dialect:             smb2.SMB302,
+		capabilities:        smb2.SMB2_GLOBAL_CAP_LARGE_MTU,
+		maxReadSize:         bufSize,
+		maxWriteSize:        bufSize,
+		maxTransactSize:     bufSize,
+	}
+	c.sequenceWindow = 1
+	c.account.charge(8, 8) // 1 initial + 8 == startBalance spendable credits
+	return c
+}
+
+// newReadReq mirrors what client.go's readAtChunk builds, with CreditCharge set
+// explicitly to the amount loaned for this request. A zero-value FileId encodes
+// fine because nothing decodes it in these tests.
+func newReadReq(creditCharge uint16) *smb2.ReadRequest {
+	req := &smb2.ReadRequest{
+		Length:       64 * 1024 * uint32(creditCharge),
+		Offset:       0,
+		FileId:       &smb2.FileId{},
+		MinimumCount: 0,
+	}
+	req.CreditCharge = creditCharge
+	return req
+}
+
+// TestSendWithRollsBackWindowOnAbandonedSend pins invariant 1 for sendWith.
+//
+// The "abandoned-send" subtest drives sendWith's outer `case <-ctx.Done()` arm:
+// makeRequestResponse has already allocated a message ID and advanced the
+// window, but the packet never reaches the writer because the write channel is
+// full and the context is cancelled while the handoff is blocked. The loan must
+// be refunded and the window must roll back. The "conn-err" and
+// "ctx-already-done" subtests cover the two pre-registration refund arms, which
+// never advance the window.
+func TestSendWithRollsBackWindowOnAbandonedSend(t *testing.T) {
+	t.Run("abandoned-send", func(t *testing.T) {
+		require := require.New(t)
+
+		c := newRollbackConn()
+
+		// Loan 2 credits: balance drops to startBalance-2.
+		loaned, _, err := c.account.loan(context.Background(), 2)
+		require.NoError(err)
+		require.EqualValues(2, loaned)
+		require.Equal(startBalance-2, len(c.account.balance))
+
+		req := newReadReq(loaned)
+
+		// Fill the single-slot write channel so the handoff in sendWith can never
+		// proceed and the outer ctx.Done() arm is the only exit.
+		c.write <- []byte{}
+
+		// Cancel only after sendWith is blocked on the write handoff. A too-early
+		// cancel (before the early check at the top of sendWith) would instead
+		// take the pre-registration refund arm, which never advances the window;
+		// the window assertion would then be vacuous but not incorrect.
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			cancel()
+		}()
+
+		rr, err := c.sendWith(ctx, req, nil, loaned)
+
+		// 1. The abandoned send fails with the context error and yields no rr.
+		require.ErrorIs(err, context.Canceled)
+		require.Nil(rr)
+
+		// 2. The loan is refunded: balance is back to startBalance.
+		require.Equal(startBalance, len(c.account.balance),
+			"loan must be refunded on the abandoned-send arm")
+
+		// 3. The window rolls back to 1: the allocated message ID is given back
+		//    because it was never transmitted. Before the rollback fix this
+		//    failed with sequenceWindow stuck at 3.
+		require.EqualValues(1, c.sequenceWindow,
+			"window must roll back when the packet is never transmitted")
+	})
+
+	t.Run("conn-err", func(t *testing.T) {
+		require := require.New(t)
+
+		c := newRollbackConn()
+
+		// A prior fatal error on the connection makes sendWith refund and return
+		// before it ever allocates a message ID.
+		errBoom := errors.New("connection already failed")
+		c.err = errBoom
+
+		loaned, _, err := c.account.loan(context.Background(), 2)
+		require.NoError(err)
+		require.EqualValues(2, loaned)
+
+		req := newReadReq(loaned)
+
+		rr, err := c.sendWith(context.Background(), req, nil, loaned)
+
+		require.ErrorIs(err, errBoom)
+		require.Nil(rr)
+		// Refunded, and the window was never advanced.
+		require.Equal(startBalance, len(c.account.balance))
+		require.EqualValues(1, c.sequenceWindow)
+	})
+
+	t.Run("ctx-already-done", func(t *testing.T) {
+		require := require.New(t)
+
+		c := newRollbackConn()
+
+		loaned, _, err := c.account.loan(context.Background(), 2)
+		require.NoError(err)
+		require.EqualValues(2, loaned)
+
+		req := newReadReq(loaned)
+
+		// An already-cancelled context is caught by the early select at the top
+		// of sendWith, refunding before any message ID is allocated.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		rr, err := c.sendWith(ctx, req, nil, loaned)
+
+		require.ErrorIs(err, context.Canceled)
+		require.Nil(rr)
+		require.Equal(startBalance, len(c.account.balance))
+		require.EqualValues(1, c.sequenceWindow)
+	})
+}
+
+// TestSendCompoundRollsBackWindowOnAbandonedSend pins invariant 1 for
+// sendCompound with a multi-entry batch. The "abandoned-send" subtest drives the
+// outer `case <-ctx.Done()` arm: all three requests have been registered and the
+// window advanced by the batch's total credit charge, but the frame never
+// reaches the writer. refundCompound must restore the batch's credits, and the
+// window must roll back by the batch total. The "ctx-already-done" subtest
+// covers the pre-flight refund arm, which never advances the window.
+func TestSendCompoundRollsBackWindowOnAbandonedSend(t *testing.T) {
+	// CreditCharges 1, 2, 3 sum to a batch total of 6.
+	const batchTotal = 6
+
+	t.Run("abandoned-send", func(t *testing.T) {
+		require := require.New(t)
+
+		c := newRollbackConn()
+
+		// Loan the batch total up front: balance drops to startBalance-batchTotal.
+		loaned, _, err := c.account.loan(context.Background(), batchTotal)
+		require.NoError(err)
+		require.EqualValues(batchTotal, loaned)
+		require.Equal(startBalance-batchTotal, len(c.account.balance))
+
+		entries := []compoundEntry{
+			{req: newReadReq(1)},
+			{req: newReadReq(2)},
+			{req: newReadReq(3)},
+		}
+
+		// Fill the write channel so the frame handoff can never proceed.
+		c.write <- []byte{}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			cancel()
+		}()
+
+		rrs, err := c.sendCompound(ctx, entries)
+
+		require.ErrorIs(err, context.Canceled)
+		require.Nil(rrs)
+
+		// refundCompound restores the batch's credits.
+		require.Equal(startBalance, len(c.account.balance),
+			"batch credits must be refunded on the abandoned-send arm")
+
+		// The window rolls back by the batch total to 1. Before the rollback fix
+		// this failed with sequenceWindow stuck at 7.
+		require.EqualValues(1, c.sequenceWindow,
+			"window must roll back by the batch total when the frame is never transmitted")
+
+		// The batch's requests were evicted by refundCompound. Message IDs are
+		// allocated from sequenceWindow==1 in charge order: 1, 1+1==2, 2+2==4.
+		for _, msgId := range []uint64{1, 2, 4} {
+			_, ok := c.outstandingRequests.pop(msgId)
+			require.False(ok, "request %d must no longer be outstanding", msgId)
+		}
+	})
+
+	t.Run("ctx-already-done", func(t *testing.T) {
+		require := require.New(t)
+
+		c := newRollbackConn()
+
+		loaned, _, err := c.account.loan(context.Background(), batchTotal)
+		require.NoError(err)
+		require.EqualValues(batchTotal, loaned)
+
+		entries := []compoundEntry{
+			{req: newReadReq(1)},
+			{req: newReadReq(2)},
+			{req: newReadReq(3)},
+		}
+
+		// An already-cancelled context is caught by sendCompound's pre-flight
+		// select before any message ID is allocated.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		rrs, err := c.sendCompound(ctx, entries)
+
+		require.ErrorIs(err, context.Canceled)
+		require.Nil(rrs)
+		require.Equal(startBalance, len(c.account.balance))
+		require.EqualValues(1, c.sequenceWindow)
+	})
+}
+
 // TestPendingResponseSettlesLoanOnce is a regression guard for tryHandle's
 // STATUS_PENDING arm, which was previously untested. An interim
 // STATUS_PENDING response settles the loan (it banks the server's grant and
 // claims the loan) and re-registers the request, so a caller that later abandons
-// the request must NOT receive a second refund.
+// the request must NOT receive a second refund. Pins invariant 2.
 func TestPendingResponseSettlesLoanOnce(t *testing.T) {
 	require := require.New(t)
 
@@ -90,7 +332,8 @@ func TestPendingResponseSettlesLoanOnce(t *testing.T) {
 
 // TestRecvRefundsLoan covers recv's two real refund paths with a nonzero,
 // unclaimed loan. Existing tests only reach these arms after the loan is already
-// claimed, so the refund itself is never exercised there.
+// claimed, so the refund itself is never exercised there. Both subtests pin
+// invariant 2.
 func TestRecvRefundsLoan(t *testing.T) {
 	t.Run("ctx-eviction", func(t *testing.T) {
 		require := require.New(t)

--- a/credit_refund_test.go
+++ b/credit_refund_test.go
@@ -1,0 +1,172 @@
+package smb2
+
+// White-box tests hardening the single-owner credit settlement rule introduced
+// by the double-settlement fix: each requestResponse carries its loan in an
+// atomic; claimLoan swap-takes it exactly once, so whichever of the receiver or
+// a failure path evicts the request settles the loan, and the loser's refund
+// becomes a no-op charge of zero. The paths covered here — tryHandle's
+// STATUS_PENDING arm and recv's two refund arms with a nonzero, unclaimed
+// loan — were previously untested.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudsoda/go-smb2/internal/erref"
+	"github.com/cloudsoda/go-smb2/internal/smb2"
+)
+
+// startBalance is the spendable credit count after opening a fresh test account
+// up from its initial single credit.
+const startBalance = 9
+
+// TestPendingResponseSettlesLoanOnce is a regression guard for tryHandle's
+// STATUS_PENDING arm, which was previously untested. An interim
+// STATUS_PENDING response settles the loan (it banks the server's grant and
+// claims the loan) and re-registers the request, so a caller that later abandons
+// the request must NOT receive a second refund.
+func TestPendingResponseSettlesLoanOnce(t *testing.T) {
+	require := require.New(t)
+
+	c := &conn{
+		outstandingRequests: newOutstandingRequests(),
+		account:             openAccount(128),
+	}
+	c.account.charge(8, 8)
+	require.Equal(startBalance, len(c.account.balance))
+
+	// The caller's context is already done, so when it later calls recv both of
+	// recv's select arms would be ready.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	loaned, _, err := c.account.loan(context.Background(), 2)
+	require.NoError(err)
+	require.EqualValues(2, loaned)
+	require.Equal(startBalance-2, len(c.account.balance))
+
+	const msgId = 5
+	rr := &requestResponse{
+		msgId:         msgId,
+		ctx:           ctx,
+		recv:          make(chan []byte, 1),
+		creditRequest: 2,
+	}
+	rr.loan.Store(uint32(loaned))
+	c.outstandingRequests.set(msgId, rr)
+
+	// An interim STATUS_PENDING response granting 2 credits. A plain 64-byte
+	// buffer gives asyncId 0, which is fine for the AsyncId() read on this arm.
+	pkt := make([]byte, 64)
+	p := smb2.PacketCodec(pkt)
+	p.SetMessageId(msgId)
+	p.SetStatus(uint32(erref.STATUS_PENDING))
+	p.SetCreditResponse(2)
+
+	require.NoError(c.tryHandle(pkt, nil, nil))
+
+	// The grant of 2 is banked against creditRequest 2, so balance returns to
+	// startBalance, and the request is re-registered for the final response.
+	require.Equal(startBalance, len(c.account.balance),
+		"the pending grant must bank the loan back exactly once")
+
+	c.outstandingRequests.m.Lock()
+	_, present := c.outstandingRequests.requests[msgId]
+	c.outstandingRequests.m.Unlock()
+	require.True(present, "STATUS_PENDING must re-register the request")
+
+	// The caller now abandons the request: recv's ctx arm pops the re-registered
+	// request and calls claimLoan, which yields 0 because tryHandle already
+	// settled the loan. No second refund fires, so the balance stays at
+	// startBalance rather than climbing to 11.
+	_, err = c.recv(rr)
+	require.Error(err)
+	require.Equal(startBalance, len(c.account.balance),
+		"a settled loan must not be refunded a second time")
+}
+
+// TestRecvRefundsLoan covers recv's two real refund paths with a nonzero,
+// unclaimed loan. Existing tests only reach these arms after the loan is already
+// claimed, so the refund itself is never exercised there.
+func TestRecvRefundsLoan(t *testing.T) {
+	t.Run("ctx-eviction", func(t *testing.T) {
+		require := require.New(t)
+
+		c := &conn{
+			outstandingRequests: newOutstandingRequests(),
+			account:             openAccount(128),
+		}
+		c.account.charge(8, 8)
+		require.Equal(startBalance, len(c.account.balance))
+
+		loaned, _, err := c.account.loan(context.Background(), 2)
+		require.NoError(err)
+		require.EqualValues(2, loaned)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		const msgId = 7
+		rr := &requestResponse{
+			msgId: msgId,
+			ctx:   ctx,
+			recv:  make(chan []byte, 1),
+		}
+		rr.loan.Store(uint32(loaned))
+		c.outstandingRequests.set(msgId, rr)
+
+		// recv's recv channel is empty, so the cancelled-context arm wins: it pops
+		// the request and refunds the still-unclaimed loan.
+		_, err = c.recv(rr)
+		require.ErrorIs(err, context.Canceled)
+		require.Equal(startBalance, len(c.account.balance),
+			"the ctx arm must refund an unclaimed loan")
+
+		_, ok := c.outstandingRequests.pop(msgId)
+		require.False(ok, "recv must have evicted the request")
+	})
+
+	t.Run("shutdown", func(t *testing.T) {
+		require := require.New(t)
+
+		c := &conn{
+			outstandingRequests: newOutstandingRequests(),
+			account:             openAccount(128),
+		}
+		c.account.charge(8, 8)
+		require.Equal(startBalance, len(c.account.balance))
+
+		loaned, _, err := c.account.loan(context.Background(), 2)
+		require.NoError(err)
+		require.EqualValues(2, loaned)
+
+		// A live (non-cancelled) context, so the pkt arm — not the ctx arm — is the
+		// one that fires.
+		const msgId = 8
+		rr := &requestResponse{
+			msgId: msgId,
+			ctx:   context.Background(),
+			recv:  make(chan []byte, 1),
+		}
+		rr.loan.Store(uint32(loaned))
+		c.outstandingRequests.set(msgId, rr)
+
+		// Transport shutdown sets rr.err and closes rr.recv WITHOUT evicting the
+		// request, so no one has settled the loan yet.
+		errShutdown := errors.New("transport shut down")
+		c.outstandingRequests.shutdown(errShutdown)
+
+		// recv takes the pkt arm on the closed channel, sees rr.err, and refunds.
+		_, err = c.recv(rr)
+		require.ErrorIs(err, errShutdown)
+		require.Equal(startBalance, len(c.account.balance),
+			"the shutdown path must refund an unclaimed loan")
+
+		// The loan was settled exactly once: a second claim yields nothing, so no
+		// double refund is possible.
+		require.Zero(rr.claimLoan(), "the loan must already be claimed")
+	})
+}

--- a/credit_refund_test.go
+++ b/credit_refund_test.go
@@ -1,24 +1,21 @@
 package smb2
 
-// White-box tests for the credit refund/settlement paths in conn.go.
+// White-box tests for the credit refund and settlement paths in conn.go.
 //
 // Two invariants are under test:
 //
-//  1. The window/credit invariant (SEQUENCE-ROLLBACK.md): after any send that
-//     fails before the packet reaches the writer, conn.sequenceWindow (the next
-//     message ID the client will allocate) plus len(conn.account.balance) (the
-//     spendable credit count) must equal the server's window ceiling. A send that
-//     allocates a message ID but never transmits it must roll the window back, or
-//     the client's ID counter drifts ahead of what its balance can address.
+//  1. Window/credit: conn.sequenceWindow (the next message ID the client will
+//     allocate) plus len(conn.account.balance) (the spendable credit count) must
+//     equal the server's window ceiling. A send that allocates a message ID but
+//     never transmits it must roll the window back, or the ID counter drifts
+//     ahead of what the balance can address.
 //
-//  2. Single-owner settlement (commit 62dc3c9): each requestResponse carries its
-//     loan in an atomic; claimLoan swap-takes it exactly once, so whichever of the
-//     receiver or a failure path evicts the request settles the loan, and the
-//     loser's refund becomes a no-op charge of zero.
+//  2. Single-owner settlement: each requestResponse carries its loan in an
+//     atomic; claimLoan swap-takes it exactly once, so whichever of the receiver
+//     or a failure path pops the request settles the loan, and any later claim
+//     yields zero.
 //
-// TestSendWith... and TestSendCompound... are regression tests for invariant 1:
-// before the rollback fix, their sequenceWindow assertions failed (the window
-// stayed advanced at 3 and 7) while the refund assertions passed.
+// TestSendWith... and TestSendCompound... pin invariant 1;
 // TestPendingResponseSettlesLoanOnce and TestRecvRefundsLoan pin invariant 2.
 
 import (
@@ -55,12 +52,12 @@ func newRollbackConn() *conn {
 		maxTransactSize:     bufSize,
 	}
 	c.sequenceWindow = 1
-	c.account.charge(8, 8) // 1 initial + 8 == startBalance spendable credits
+	c.account.settle(8, 8) // 1 initial + 8 == startBalance spendable credits
 	return c
 }
 
 // newReadReq mirrors what client.go's readAtChunk builds, with CreditCharge set
-// explicitly to the amount loaned for this request. A zero-value FileId encodes
+// explicitly to the amount borrowed for this request. A zero-value FileId encodes
 // fine because nothing decodes it in these tests.
 func newReadReq(creditCharge uint16) *smb2.ReadRequest {
 	req := &smb2.ReadRequest{
@@ -88,13 +85,13 @@ func TestSendWithRollsBackWindowOnAbandonedSend(t *testing.T) {
 
 		c := newRollbackConn()
 
-		// Loan 2 credits: balance drops to startBalance-2.
-		loaned, _, err := c.account.loan(context.Background(), 2)
+		// Borrow 2 credits: balance drops to startBalance-2.
+		borrowed, _, err := c.account.borrow(context.Background(), 2)
 		require.NoError(err)
-		require.EqualValues(2, loaned)
+		require.EqualValues(2, borrowed)
 		require.Equal(startBalance-2, len(c.account.balance))
 
-		req := newReadReq(loaned)
+		req := newReadReq(borrowed)
 
 		// Fill the single-slot write channel so the handoff in sendWith can never
 		// proceed and the outer ctx.Done() arm is the only exit.
@@ -110,7 +107,7 @@ func TestSendWithRollsBackWindowOnAbandonedSend(t *testing.T) {
 			cancel()
 		}()
 
-		rr, err := c.sendWith(ctx, req, nil, loaned)
+		rr, err := c.sendWith(ctx, req, nil, borrowed)
 
 		// 1. The abandoned send fails with the context error and yields no rr.
 		require.ErrorIs(err, context.Canceled)
@@ -121,8 +118,7 @@ func TestSendWithRollsBackWindowOnAbandonedSend(t *testing.T) {
 			"loan must be refunded on the abandoned-send arm")
 
 		// 3. The window rolls back to 1: the allocated message ID is given back
-		//    because it was never transmitted. Before the rollback fix this
-		//    failed with sequenceWindow stuck at 3.
+		//    because it was never transmitted.
 		require.EqualValues(1, c.sequenceWindow,
 			"window must roll back when the packet is never transmitted")
 	})
@@ -137,13 +133,13 @@ func TestSendWithRollsBackWindowOnAbandonedSend(t *testing.T) {
 		errBoom := errors.New("connection already failed")
 		c.err = errBoom
 
-		loaned, _, err := c.account.loan(context.Background(), 2)
+		borrowed, _, err := c.account.borrow(context.Background(), 2)
 		require.NoError(err)
-		require.EqualValues(2, loaned)
+		require.EqualValues(2, borrowed)
 
-		req := newReadReq(loaned)
+		req := newReadReq(borrowed)
 
-		rr, err := c.sendWith(context.Background(), req, nil, loaned)
+		rr, err := c.sendWith(context.Background(), req, nil, borrowed)
 
 		require.ErrorIs(err, errBoom)
 		require.Nil(rr)
@@ -157,18 +153,18 @@ func TestSendWithRollsBackWindowOnAbandonedSend(t *testing.T) {
 
 		c := newRollbackConn()
 
-		loaned, _, err := c.account.loan(context.Background(), 2)
+		borrowed, _, err := c.account.borrow(context.Background(), 2)
 		require.NoError(err)
-		require.EqualValues(2, loaned)
+		require.EqualValues(2, borrowed)
 
-		req := newReadReq(loaned)
+		req := newReadReq(borrowed)
 
 		// An already-cancelled context is caught by the early select at the top
 		// of sendWith, refunding before any message ID is allocated.
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		rr, err := c.sendWith(ctx, req, nil, loaned)
+		rr, err := c.sendWith(ctx, req, nil, borrowed)
 
 		require.ErrorIs(err, context.Canceled)
 		require.Nil(rr)
@@ -193,10 +189,10 @@ func TestSendCompoundRollsBackWindowOnAbandonedSend(t *testing.T) {
 
 		c := newRollbackConn()
 
-		// Loan the batch total up front: balance drops to startBalance-batchTotal.
-		loaned, _, err := c.account.loan(context.Background(), batchTotal)
+		// Borrow the batch total up front: balance drops to startBalance-batchTotal.
+		borrowed, _, err := c.account.borrow(context.Background(), batchTotal)
 		require.NoError(err)
-		require.EqualValues(batchTotal, loaned)
+		require.EqualValues(batchTotal, borrowed)
 		require.Equal(startBalance-batchTotal, len(c.account.balance))
 
 		entries := []compoundEntry{
@@ -223,12 +219,11 @@ func TestSendCompoundRollsBackWindowOnAbandonedSend(t *testing.T) {
 		require.Equal(startBalance, len(c.account.balance),
 			"batch credits must be refunded on the abandoned-send arm")
 
-		// The window rolls back by the batch total to 1. Before the rollback fix
-		// this failed with sequenceWindow stuck at 7.
+		// The window rolls back by the batch total to 1.
 		require.EqualValues(1, c.sequenceWindow,
 			"window must roll back by the batch total when the frame is never transmitted")
 
-		// The batch's requests were evicted by refundCompound. Message IDs are
+		// The batch's requests were popped by refundCompound. Message IDs are
 		// allocated from sequenceWindow==1 in charge order: 1, 1+1==2, 2+2==4.
 		for _, msgId := range []uint64{1, 2, 4} {
 			_, ok := c.outstandingRequests.pop(msgId)
@@ -241,9 +236,9 @@ func TestSendCompoundRollsBackWindowOnAbandonedSend(t *testing.T) {
 
 		c := newRollbackConn()
 
-		loaned, _, err := c.account.loan(context.Background(), batchTotal)
+		borrowed, _, err := c.account.borrow(context.Background(), batchTotal)
 		require.NoError(err)
-		require.EqualValues(batchTotal, loaned)
+		require.EqualValues(batchTotal, borrowed)
 
 		entries := []compoundEntry{
 			{req: newReadReq(1)},
@@ -277,17 +272,17 @@ func TestPendingResponseSettlesLoanOnce(t *testing.T) {
 		outstandingRequests: newOutstandingRequests(),
 		account:             openAccount(128),
 	}
-	c.account.charge(8, 8)
+	c.account.settle(8, 8)
 	require.Equal(startBalance, len(c.account.balance))
 
-	// The caller's context is already done, so when it later calls recv both of
-	// recv's select arms would be ready.
+	// The caller's context is already done, so the later recv call could return
+	// by either path.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	loaned, _, err := c.account.loan(context.Background(), 2)
+	borrowed, _, err := c.account.borrow(context.Background(), 2)
 	require.NoError(err)
-	require.EqualValues(2, loaned)
+	require.EqualValues(2, borrowed)
 	require.Equal(startBalance-2, len(c.account.balance))
 
 	const msgId = 5
@@ -297,7 +292,7 @@ func TestPendingResponseSettlesLoanOnce(t *testing.T) {
 		recv:          make(chan []byte, 1),
 		creditRequest: 2,
 	}
-	rr.loan.Store(uint32(loaned))
+	rr.loan.Store(uint32(borrowed))
 	c.outstandingRequests.set(msgId, rr)
 
 	// An interim STATUS_PENDING response granting 2 credits. A plain 64-byte
@@ -335,19 +330,19 @@ func TestPendingResponseSettlesLoanOnce(t *testing.T) {
 // claimed, so the refund itself is never exercised there. Both subtests pin
 // invariant 2.
 func TestRecvRefundsLoan(t *testing.T) {
-	t.Run("ctx-eviction", func(t *testing.T) {
+	t.Run("ctx-pop", func(t *testing.T) {
 		require := require.New(t)
 
 		c := &conn{
 			outstandingRequests: newOutstandingRequests(),
 			account:             openAccount(128),
 		}
-		c.account.charge(8, 8)
+		c.account.settle(8, 8)
 		require.Equal(startBalance, len(c.account.balance))
 
-		loaned, _, err := c.account.loan(context.Background(), 2)
+		borrowed, _, err := c.account.borrow(context.Background(), 2)
 		require.NoError(err)
-		require.EqualValues(2, loaned)
+		require.EqualValues(2, borrowed)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -358,7 +353,7 @@ func TestRecvRefundsLoan(t *testing.T) {
 			ctx:   ctx,
 			recv:  make(chan []byte, 1),
 		}
-		rr.loan.Store(uint32(loaned))
+		rr.loan.Store(uint32(borrowed))
 		c.outstandingRequests.set(msgId, rr)
 
 		// recv's recv channel is empty, so the cancelled-context arm wins: it pops
@@ -369,7 +364,7 @@ func TestRecvRefundsLoan(t *testing.T) {
 			"the ctx arm must refund an unclaimed loan")
 
 		_, ok := c.outstandingRequests.pop(msgId)
-		require.False(ok, "recv must have evicted the request")
+		require.False(ok, "recv must have popped the request")
 	})
 
 	t.Run("shutdown", func(t *testing.T) {
@@ -379,12 +374,12 @@ func TestRecvRefundsLoan(t *testing.T) {
 			outstandingRequests: newOutstandingRequests(),
 			account:             openAccount(128),
 		}
-		c.account.charge(8, 8)
+		c.account.settle(8, 8)
 		require.Equal(startBalance, len(c.account.balance))
 
-		loaned, _, err := c.account.loan(context.Background(), 2)
+		borrowed, _, err := c.account.borrow(context.Background(), 2)
 		require.NoError(err)
-		require.EqualValues(2, loaned)
+		require.EqualValues(2, borrowed)
 
 		// A live (non-cancelled) context, so the pkt arm — not the ctx arm — is the
 		// one that fires.
@@ -394,10 +389,10 @@ func TestRecvRefundsLoan(t *testing.T) {
 			ctx:   context.Background(),
 			recv:  make(chan []byte, 1),
 		}
-		rr.loan.Store(uint32(loaned))
+		rr.loan.Store(uint32(borrowed))
 		c.outstandingRequests.set(msgId, rr)
 
-		// Transport shutdown sets rr.err and closes rr.recv WITHOUT evicting the
+		// Transport shutdown sets rr.err and closes rr.recv WITHOUT popping the
 		// request, so no one has settled the loan yet.
 		errShutdown := errors.New("transport shut down")
 		c.outstandingRequests.shutdown(errShutdown)

--- a/tree_conn.go
+++ b/tree_conn.go
@@ -41,19 +41,19 @@ func (tc *treeConn) compoundSecurityInfoBatch(
 	for off := 0; off < len(paths); {
 		remaining := len(paths) - off
 
-		// Loan credits: 3 per file (CREATE + QUERY_INFO + CLOSE).
+		// Borrow credits: 3 per file (CREATE + QUERY_INFO + CLOSE).
 		// Compute in int to avoid uint16 overflow on large directories,
 		// then clamp to the credit balance capacity.
 		wanted := min(remaining*3, cap(tc.account.balance))
 
-		granted, _, err := tc.account.loan(ctx, uint16(wanted))
+		granted, _, err := tc.account.borrow(ctx, uint16(wanted))
 		if err != nil {
 			return nil, err
 		}
 
 		batchSize := int(granted / 3)
 		if batchSize == 0 {
-			tc.chargeCredit(granted)
+			tc.refundCredits(granted)
 			return nil, &InternalError{"insufficient credits for compound request"}
 		}
 		if batchSize > remaining {
@@ -62,7 +62,7 @@ func (tc *treeConn) compoundSecurityInfoBatch(
 
 		// Return excess credits.
 		if excess := granted - uint16(batchSize*3); excess > 0 {
-			tc.chargeCredit(excess)
+			tc.refundCredits(excess)
 		}
 
 		err = tc.sendSecurityBatch(paths[off:off+batchSize], results[off:off+batchSize], access, securityInfo, mapping, ctx)
@@ -243,7 +243,10 @@ func (tc *treeConn) disconnect(ctx context.Context) error {
 
 	req.CreditCharge = 1
 
-	res, err := tc.sendRecvUnloaned(ctx, smb2.SMB2_TREE_DISCONNECT, req)
+	// Sent without borrowing: disconnect runs during teardown, where waiting in
+	// borrowCredits on credits held by requests that may never return would turn
+	// a fast-failing unmount into one that blocks until the context expires.
+	res, err := tc.sendRecvUnborrowed(ctx, smb2.SMB2_TREE_DISCONNECT, req)
 	if err != nil {
 		return err
 	}
@@ -256,16 +259,14 @@ func (tc *treeConn) disconnect(ctx context.Context) error {
 	return nil
 }
 
-// send transmits a request whose CreditCharge was loaned from the account, so
-// the loan is refunded if the send fails. Credit settlement is owned by the
-// conn layer (sendWith/recv); callers must not refund separately.
+// send transmits a request, registering its CreditCharge as the loan borrowed
+// from the account for it.
 func (tc *treeConn) send(ctx context.Context, req smb2.Packet) (rr *requestResponse, err error) {
 	return tc.sendWith(ctx, req, tc, req.Header().CreditCharge)
 }
 
-// sendRecv sends a loaned request and waits for its response. An error status
-// returned by the server (surfaced by accept) is a settled response, not a
-// refundable failure — the conn layer already charged its credits back.
+// sendRecv sends a request via send and returns its accepted response payload.
+// A server error status surfaces as the *ResponseError synthesized by accept.
 func (tc *treeConn) sendRecv(ctx context.Context, cmd uint16, req smb2.Packet) (res []byte, err error) {
 	rr, err := tc.send(ctx, req)
 	if err != nil {
@@ -280,20 +281,13 @@ func (tc *treeConn) sendRecv(ctx context.Context, cmd uint16, req smb2.Packet) (
 	return accept(cmd, pkt)
 }
 
-// sendUnloaned transmits a request that did not draw its CreditCharge from the
-// account, so a failure has nothing to refund. Tree disconnect is the only such
-// request: it runs during teardown, where waiting in loanCredit on credits held
-// by requests that may never return would turn a fast-failing unmount into one
-// that blocks until the context expires. The cost is that the response's grant
-// is banked against a charge the account never paid, inflating the balance by
-// one credit per unmount.
-func (tc *treeConn) sendUnloaned(ctx context.Context, req smb2.Packet) (rr *requestResponse, err error) {
-	return tc.sendWith(ctx, req, tc, 0)
-}
-
-// sendRecvUnloaned is sendRecv for an unloaned request. See sendUnloaned.
-func (tc *treeConn) sendRecvUnloaned(ctx context.Context, cmd uint16, req smb2.Packet) (res []byte, err error) {
-	rr, err := tc.sendUnloaned(ctx, req)
+// sendRecvUnborrowed is sendRecv for a request whose CreditCharge was not drawn
+// from the account.
+func (tc *treeConn) sendRecvUnborrowed(ctx context.Context, cmd uint16, req smb2.Packet) (res []byte, err error) {
+	// A 0 loan: nothing was borrowed, so a failure refunds nothing. The cost is
+	// that the response's grant is banked against a debt the account never
+	// incurred, inflating the balance by one credit per such request.
+	rr, err := tc.sendWith(ctx, req, tc, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/tree_conn.go
+++ b/tree_conn.go
@@ -243,7 +243,7 @@ func (tc *treeConn) disconnect(ctx context.Context) error {
 
 	req.CreditCharge = 1
 
-	res, err := tc.sendRecv(ctx, smb2.SMB2_TREE_DISCONNECT, req)
+	res, err := tc.sendRecvUnloaned(ctx, smb2.SMB2_TREE_DISCONNECT, req)
 	if err != nil {
 		return err
 	}
@@ -256,6 +256,16 @@ func (tc *treeConn) disconnect(ctx context.Context) error {
 	return nil
 }
 
+// send transmits a request whose CreditCharge was loaned from the account, so
+// the loan is refunded if the send fails. Credit settlement is owned by the
+// conn layer (sendWith/recv); callers must not refund separately.
+func (tc *treeConn) send(ctx context.Context, req smb2.Packet) (rr *requestResponse, err error) {
+	return tc.sendWith(ctx, req, tc, req.Header().CreditCharge)
+}
+
+// sendRecv sends a loaned request and waits for its response. An error status
+// returned by the server (surfaced by accept) is a settled response, not a
+// refundable failure — the conn layer already charged its credits back.
 func (tc *treeConn) sendRecv(ctx context.Context, cmd uint16, req smb2.Packet) (res []byte, err error) {
 	rr, err := tc.send(ctx, req)
 	if err != nil {
@@ -270,8 +280,30 @@ func (tc *treeConn) sendRecv(ctx context.Context, cmd uint16, req smb2.Packet) (
 	return accept(cmd, pkt)
 }
 
-func (tc *treeConn) send(ctx context.Context, req smb2.Packet) (rr *requestResponse, err error) {
-	return tc.sendWith(ctx, req, tc)
+// sendUnloaned transmits a request that did not draw its CreditCharge from the
+// account, so a failure has nothing to refund. Tree disconnect is the only such
+// request: it runs during teardown, where waiting in loanCredit on credits held
+// by requests that may never return would turn a fast-failing unmount into one
+// that blocks until the context expires. The cost is that the response's grant
+// is banked against a charge the account never paid, inflating the balance by
+// one credit per unmount.
+func (tc *treeConn) sendUnloaned(ctx context.Context, req smb2.Packet) (rr *requestResponse, err error) {
+	return tc.sendWith(ctx, req, tc, 0)
+}
+
+// sendRecvUnloaned is sendRecv for an unloaned request. See sendUnloaned.
+func (tc *treeConn) sendRecvUnloaned(ctx context.Context, cmd uint16, req smb2.Packet) (res []byte, err error) {
+	rr, err := tc.sendUnloaned(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	pkt, err := tc.recv(rr)
+	if err != nil {
+		return nil, err
+	}
+
+	return accept(cmd, pkt)
 }
 
 func (tc *treeConn) recv(rr *requestResponse) (pkt []byte, err error) {


### PR DESCRIPTION
This PR fixes two credit-accounting bugs, each of which violates the invariant
relating client's ledger to the server's command sequence window (MS-SMB2 3.3.5.2.3):

```
next message ID (conn.sequenceWindow) + spendable credits (account balance)
    == server's window ceiling (1 + total credits granted)
```

Once either side drifts, the client eventually addresses a message ID past
the top of the server's window; a strict server answers
`STATUS_INVALID_PARAMETER` or drops the connection, and with signing enabled
the teardown also surfaces as spurious "packet failed signature verification"
errors.

### 1. Fix double-settlement of credits on error-status responses (62dc3c9)

Credit loans were settled twice whenever an operation completed with an
error-status response: the receiver banks the server's `CreditResponse` for
every non-pending response, but each loaning operation in `client.go` also
carried a `defer` that refunded the loan on error — and it fired on the
`ResponseError` synthesized from the error status. Every routine failure
(`NOT_FOUND`, `ACCESS_DENIED`, `END_OF_FILE`, symlink chases) fabricated one
credit of balance, so concurrent callers on a shared session — or one deep
compound ReaddirPlus batch — spent credits the server never granted and
overran the window. A related leak in `sendSecurityBatch` erred the other
way, refunding nothing on transport errors.

The fix makes settlement owned solely by the conn layer. The loan rides on
the `requestResponse`, and `claimLoan()` atomically sets the charge:
a response settles the loan when the receiver charges it, and failure paths
refund only what a response has not already claimed, gated on evicting the
request from `outstandingRequests`. All ten `client.go` refund defers are
removed. **Reproduced against a real Windows server:** the parent build
deadlocks or gets RST under a shared-session compound workload at the credit
window; this build runs it clean.

### 2. Add regression tests for single-owner credit settlement (3c73021)

White-box tests for settlement paths the fix's original regression test
never reached: the interim `STATUS_PENDING` response (which settles the loan
so a later abandonment cannot refund it a second time) and `recv`'s two
refund arms with a nonzero, unclaimed loan (cancelled-context eviction and
transport shutdown). These pin the exactly-once rule so a regression fails
loudly instead of as silent balance drift.

### 3. Roll back the sequence window when a send is abandoned before transmission (c22e564)

The complementary bug, found while reviewing the first fix: when a send
fails *before* the packet reaches the writer goroutine (context cancellation
racing a stalled writer, or an encrypt error), the credits were refunded but
the allocated message ID was not. The server's window retains the abandoned
ID forever, so the client holds N credits but only N−1 usable ID slots, and
the shortfall accumulates per occurrence. Here the credit *counts* stay
balanced; what diverges is the ID counter.

The fix rolls `conn.sequenceWindow` back on the pre-handoff failure paths in
`sendWith`, `sendCompound`, and `makeRequestResponse`, where it is safe:
`conn.m` is held from ID allocation through the write handoff, so no later
ID can exist. The rollback is skipped for `CancelRequest` (which never
advances the window) and deliberately absent from post-handoff paths, where
the packet may already be on the wire and the ID is burned either way. New
tests drive both send paths into the abandoned-send arm with a stalled
writer and assert both halves of the ledger; before the fix the window
assertions failed with the counter stuck ahead by exactly the abandoned
charges.

### Testing

- `credit_books_test.go`: a fake server keeping honest credit books flags
  any request whose `[MessageId, MessageId+CreditCharge)` range exceeds the
  credits granted; both subtests show zero fabricated credits and zero
  window violations.
- `credit_refund_test.go`: white-box coverage of every reachable refund and
  settlement arm (the exceptions are the write-error arms and GCM
  encrypt-failure paths, which need fault injection).
- Full suite passes under `-race`; verified against a real Windows server
  over a wired LAN as described in 62dc3c9's commit message.
