### PR TITLE
Only sign requests when signing is required by the user or server

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -368,6 +368,39 @@ func (conn *conn) refundCredits(creditCharge uint16) {
 	conn.account.settle(creditCharge, creditCharge)
 }
 
+/*
+mustSign returns true if req needs to be signed.
+
+MS-SMB2 3.2.4.1.1 describes when a message needs to be signed.
+https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/973630a8-8aa1-4398-89a8-13cf830f194d
+
+SESSION_SETUP doesn't rely on this method and always signs.
+*/
+func (conn *conn) mustSign(req smb2.Packet) bool {
+	// true if the library user requested it at initialization or if the server
+	// requires it
+	if conn.requireSigning {
+		return true
+	}
+
+	// // Only SMB 3.1.1 requires TREE_CONNECT to always be signed, but for
+	// // simplicity's sake, we'll sign it no matter the dialect version.
+	_, isTreeConnect := req.(*smb2.TreeConnectRequest)
+	return isTreeConnect
+}
+
+// mustSignAny reports whether any individual entry in the compound request
+// needs to be signed. If one needs to be signed, then they should all be
+// signed.
+func (conn *conn) mustSignAny(entries []compoundEntry) bool {
+	for _, entry := range entries {
+		if conn.mustSign(entry.req) {
+			return true
+		}
+	}
+	return false
+}
+
 // send transmits a control request that did not borrow credits from the account
 // (negotiate, session setup, tree connect, echo, ...). borrowed is 0, so a
 // failure refunds nothing.
@@ -585,7 +618,7 @@ func (conn *conn) sendCompound(ctx context.Context, entries []compoundEntry) ([]
 				conn.refundCredits(totalBorrowed)
 				return nil, &InternalError{err.Error()}
 			}
-		} else if s.sessionFlags&(smb2.SMB2_SESSION_FLAG_IS_GUEST|smb2.SMB2_SESSION_FLAG_IS_NULL) == 0 {
+		} else if s.sessionFlags&(smb2.SMB2_SESSION_FLAG_IS_GUEST|smb2.SMB2_SESSION_FLAG_IS_NULL) == 0 && conn.mustSignAny(entries) {
 			// Sign each packet individually in-place.
 			// Per MS-SMB2 3.3.5.2.4, the server uses the NextCommand value as the
 			// message length for signature verification (8-byte aligned size), so
@@ -721,7 +754,7 @@ func (conn *conn) makeRequestResponse(ctx context.Context, req smb2.Packet, tc *
 					return nil, &InternalError{err.Error()}
 				}
 			} else {
-				if s.sessionFlags&(smb2.SMB2_SESSION_FLAG_IS_GUEST|smb2.SMB2_SESSION_FLAG_IS_NULL) == 0 {
+				if conn.mustSign(req) && s.sessionFlags&(smb2.SMB2_SESSION_FLAG_IS_GUEST|smb2.SMB2_SESSION_FLAG_IS_NULL) == 0 {
 					pkt = s.sign(pkt)
 				}
 			}

--- a/conn.go
+++ b/conn.go
@@ -383,8 +383,8 @@ func (conn *conn) mustSign(req smb2.Packet) bool {
 		return true
 	}
 
-	// // Only SMB 3.1.1 requires TREE_CONNECT to always be signed, but for
-	// // simplicity's sake, we'll sign it no matter the dialect version.
+	// Only SMB 3.1.1 requires TREE_CONNECT to always be signed, but for
+	// simplicity's sake, we'll sign it no matter the dialect version.
 	_, isTreeConnect := req.(*smb2.TreeConnectRequest)
 	return isTreeConnect
 }

--- a/conn.go
+++ b/conn.go
@@ -373,10 +373,13 @@ mustSign returns true if req needs to be signed.
 
 MS-SMB2 3.2.4.1.1 describes when a message needs to be signed.
 https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/973630a8-8aa1-4398-89a8-13cf830f194d
-
-SESSION_SETUP doesn't rely on this method and always signs.
 */
-func (conn *conn) mustSign(req smb2.Packet) bool {
+func (conn *conn) mustSign(sessionFlags uint16, req smb2.Packet) bool {
+	// a 'guest' user or a session without a key can't sign requests
+	if sessionFlags&(smb2.SMB2_SESSION_FLAG_IS_GUEST|smb2.SMB2_SESSION_FLAG_IS_NULL) != 0 {
+		return false
+	}
+
 	// true if the library user requested it at initialization or if the server
 	// requires it
 	if conn.requireSigning {
@@ -392,9 +395,9 @@ func (conn *conn) mustSign(req smb2.Packet) bool {
 // mustSignAny reports whether any individual entry in the compound request
 // needs to be signed. If one needs to be signed, then they should all be
 // signed.
-func (conn *conn) mustSignAny(entries []compoundEntry) bool {
+func (conn *conn) mustSignAny(sessionFlags uint16, entries []compoundEntry) bool {
 	for _, entry := range entries {
-		if conn.mustSign(entry.req) {
+		if conn.mustSign(sessionFlags, entry.req) {
 			return true
 		}
 	}
@@ -618,7 +621,7 @@ func (conn *conn) sendCompound(ctx context.Context, entries []compoundEntry) ([]
 				conn.refundCredits(totalBorrowed)
 				return nil, &InternalError{err.Error()}
 			}
-		} else if s.sessionFlags&(smb2.SMB2_SESSION_FLAG_IS_GUEST|smb2.SMB2_SESSION_FLAG_IS_NULL) == 0 && conn.mustSignAny(entries) {
+		} else if conn.mustSignAny(s.sessionFlags, entries) {
 			// Sign each packet individually in-place.
 			// Per MS-SMB2 3.3.5.2.4, the server uses the NextCommand value as the
 			// message length for signature verification (8-byte aligned size), so
@@ -754,7 +757,7 @@ func (conn *conn) makeRequestResponse(ctx context.Context, req smb2.Packet, tc *
 					return nil, &InternalError{err.Error()}
 				}
 			} else {
-				if conn.mustSign(req) && s.sessionFlags&(smb2.SMB2_SESSION_FLAG_IS_GUEST|smb2.SMB2_SESSION_FLAG_IS_NULL) == 0 {
+				if conn.mustSign(s.sessionFlags, req) {
 					pkt = s.sign(pkt)
 				}
 			}


### PR DESCRIPTION
Every request was signed whenever the session had a key, even when neither peer required it. Servers always sign a response when the request is signed, which leads to unnecessary slow transfer speeds. In my testing, transfer speeds increased 3-4x with request signing off. This is a significant gain.

Requests will still be signed when Negotitator.RequireMessageSigning is true or if the server returns SIGNING_REQUIRED during negotiation. This is the same ehavior as Windows and the Linux kernel client.

TREE_CONNECT requests are always signed.

Note for developers and downstream projects:
This commit changes the default behavior for existing callers. If you are using the library to communicate with a server and there is a chance of an attacker on the network path, you'll want to set Negotiator.RequireMessageSigning to true. However, it would be better to configure your SMB server to require signing so you don't have to worry about misconfigured clients. Even better, would be to use SMB 3+ with encryption on the server (go-smb2 supports it) so an attacker can't see your traffic at all.

For most folks, this commit is just a big transfer speed increase with reduced CPU usage and no downsides.