### PR TITLE
Expose raw security descriptors and reparse tags; fix two defects

### DIFF
--- a/client.go
+++ b/client.go
@@ -2432,12 +2432,8 @@ type FileStat struct {
 	// non-native backends do.
 	FileId uint64
 
-	// ReparsePointTag is the reparse tag (IO_REPARSE_TAG_*) when FileAttributes
-	// has FILE_ATTRIBUTE_REPARSE_POINT, 0 otherwise. It distinguishes a symlink
-	// (IO_REPARSE_TAG_SYMLINK) or junction (IO_REPARSE_TAG_MOUNT_POINT) from a
-	// dedup, HSM or cloud-placeholder file, all of which carry the same
-	// attribute bit. On the wire it is the EaSize field of
-	// FILE_ID_BOTH_DIR_INFORMATION, which the two readings share.
+	// ReparsePointTag is the tag that identifies the file system filter
+	// associated with the data when the file is a reparse point. Otherwise, 0.
 	//
 	// It is populated by File.Readdir and File.ReaddirPlus.
 	ReparsePointTag uint32

--- a/client.go
+++ b/client.go
@@ -2440,8 +2440,6 @@ type FileStat struct {
 
 	// ReparsePointTag is the tag that identifies the file system filter
 	// associated with the data when the file is a reparse point. Otherwise, 0.
-	//
-	// It is populated by File.Readdir and File.ReaddirPlus.
 	ReparsePointTag uint32
 
 	FileName string

--- a/client.go
+++ b/client.go
@@ -2337,6 +2337,7 @@ func (f *File) SecurityInfo(flags SecurityInformationRequestFlags) (*sddl.Securi
 	return sd, nil
 }
 
+// SecurityInfoRaw returns the raw security descriptor of the file as a byte array
 func (f *File) SecurityInfoRaw(info SecurityInformationRequestFlags) ([]byte, error) {
 	op := "secinfo"
 	req := &smb2.QueryInfoRequest{
@@ -2351,7 +2352,9 @@ func (f *File) SecurityInfoRaw(info SecurityInformationRequestFlags) ([]byte, er
 		return nil, &os.PathError{Op: op, Path: f.name, Err: err}
 	}
 
-	return infoBytes, nil
+	// Clone: infoBytes is a subslice of a pooled receive buffer, so after that
+	// buffer is recycled a data hazard is introduced.
+	return bytes.Clone(infoBytes), nil
 }
 
 func (f *File) SetSecurityInfo(flags SecurityInformationRequestFlags, sd *sddl.SecurityDescriptor) error {

--- a/client.go
+++ b/client.go
@@ -2,7 +2,6 @@ package smb2
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -1544,6 +1543,11 @@ func (f *File) Readdir(n int) (fi []os.FileInfo, err error) {
 //
 // Security queries use SMB2 compound requests (CREATE+QUERY_INFO+CLOSE batched
 // into single round-trips), sub-batching internally to respect credit limits.
+//
+// The returned error reflects the state of the directory listing only: nil,
+// io.EOF after the last entry, or a real Readdir failure. Security failures,
+// whether batch-wide or per-file, are reported on DirEntryPlus.Err. A caller
+// can degrade per-entry instead of abandoning the whole listing.
 func (f *File) ReaddirPlus(n int, securityInfo SecurityInformationRequestFlags) ([]DirEntryPlus, error) {
 	fi, err := f.Readdir(n)
 	if len(fi) == 0 {
@@ -1567,36 +1571,40 @@ func (f *File) ReaddirPlus(n int, securityInfo SecurityInformationRequestFlags) 
 		paths, uint32(securityInfo), f.mapping, f.fs.ctx,
 	)
 	if secErr != nil {
-		// If the compound batch itself failed, return entries without security info
-		// and propagate the batch error on the first entry.
+		// If the compound batch itself failed, return entries without security
+		// info and stamp the batch error on every entry.
 		entries := make([]DirEntryPlus, len(fi))
 		for i, info := range fi {
 			entries[i] = DirEntryPlus{FileInfo: info, Err: secErr}
 		}
-		return entries, errors.Join(err, secErr)
+		return entries, err
 	}
 
 	entries := make([]DirEntryPlus, 0, len(fi))
 	for i, info := range fi {
 		var sd *sddl.SecurityDescriptor
 		var err error
+		raw := secResults[i].data
 		if secResults[i].err != nil {
 			if isFileDeleted(secResults[i].err) {
 				continue // file deleted between Readdir and security query
 			}
 			err = secResults[i].err
-		} else if secResults[i].data != nil {
+		} else if raw != nil {
 			var parseErr error
-			sd, parseErr = sddl.FromBinary(secResults[i].data)
+			sd, parseErr = sddl.FromBinary(raw)
 			if parseErr != nil {
+				// Retain raw even on parse failure: a caller consuming the
+				// native OS representation may still succeed with these bytes.
 				sd = nil // belt-and-suspenders assignment
 				err = fmt.Errorf("parsing security descriptor for %s: %w", info.Name(), parseErr)
 			}
 		}
 		entries = append(entries, DirEntryPlus{
-			FileInfo:           info,
-			SecurityDescriptor: sd,
-			Err:                err,
+			FileInfo:              info,
+			SecurityDescriptor:    sd,
+			RawSecurityDescriptor: raw,
+			Err:                   err,
 		})
 	}
 
@@ -2260,15 +2268,16 @@ func (f *File) readdir(pattern string) (fi []os.FileInfo, err error) {
 
 		if name != "." && name != ".." {
 			fi = append(fi, &FileStat{
-				CreationTime:   time.Unix(0, info.CreationTime().Nanoseconds()),
-				LastAccessTime: time.Unix(0, info.LastAccessTime().Nanoseconds()),
-				LastWriteTime:  time.Unix(0, info.LastWriteTime().Nanoseconds()),
-				ChangeTime:     time.Unix(0, info.ChangeTime().Nanoseconds()),
-				EndOfFile:      info.EndOfFile(),
-				AllocationSize: info.AllocationSize(),
-				FileAttributes: info.FileAttributes(),
-				FileId:         info.FileId(),
-				FileName:       name,
+				CreationTime:    time.Unix(0, info.CreationTime().Nanoseconds()),
+				LastAccessTime:  time.Unix(0, info.LastAccessTime().Nanoseconds()),
+				LastWriteTime:   time.Unix(0, info.LastWriteTime().Nanoseconds()),
+				ChangeTime:      time.Unix(0, info.ChangeTime().Nanoseconds()),
+				EndOfFile:       info.EndOfFile(),
+				AllocationSize:  info.AllocationSize(),
+				FileAttributes:  info.FileAttributes(),
+				FileId:          info.FileId(),
+				ReparsePointTag: info.ReparsePointTag(),
+				FileName:        name,
 			})
 		}
 
@@ -2421,7 +2430,18 @@ type FileStat struct {
 	// response has no file id; obtain one via File.Stat on an open handle. It
 	// is also 0 when the server itself supplies none, as some legacy and
 	// non-native backends do.
-	FileId   uint64
+	FileId uint64
+
+	// ReparsePointTag is the reparse tag (IO_REPARSE_TAG_*) when FileAttributes
+	// has FILE_ATTRIBUTE_REPARSE_POINT, 0 otherwise. It distinguishes a symlink
+	// (IO_REPARSE_TAG_SYMLINK) or junction (IO_REPARSE_TAG_MOUNT_POINT) from a
+	// dedup, HSM or cloud-placeholder file, all of which carry the same
+	// attribute bit. On the wire it is the EaSize field of
+	// FILE_ID_BOTH_DIR_INFORMATION, which the two readings share.
+	//
+	// It is populated by File.Readdir and File.ReaddirPlus.
+	ReparsePointTag uint32
+
 	FileName string
 }
 
@@ -2470,6 +2490,10 @@ func (fs *FileStat) Sys() any {
 type DirEntryPlus struct {
 	os.FileInfo
 	SecurityDescriptor *sddl.SecurityDescriptor
+
+	// RawSecurityDescriptor is the security descriptor exactly as returned on
+	// the wire: a self-relative SECURITY_DESCRIPTOR blob.
+	RawSecurityDescriptor []byte
 
 	Err error // non-nil if the security query failed for this entry
 }

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package smb2
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -1584,7 +1585,9 @@ func (f *File) ReaddirPlus(n int, securityInfo SecurityInformationRequestFlags) 
 	for i, info := range fi {
 		var sd *sddl.SecurityDescriptor
 		var err error
-		raw := secResults[i].data
+		// Clone: secResults[i].data is a subslice of a pooled receive buffer, so
+		// after that buffer is recycled a data hazard is introduced.
+		raw := bytes.Clone(secResults[i].data)
 		if secResults[i].err != nil {
 			if isFileDeleted(secResults[i].err) {
 				continue // file deleted between Readdir and security query

--- a/internal/smb2/fscc.go
+++ b/internal/smb2/fscc.go
@@ -408,6 +408,20 @@ func (c FileIdBothDirectoryInformationDecoder) EaSize() uint32 {
 	return le.Uint32(c[64:68])
 }
 
+// ReparsePointTag is the reparse tag (IO_REPARSE_TAG_*) of the entry, or 0 when
+// it is not a reparse point.
+//
+// MS-FSCC 2.4.17 overloads the EaSize field: when FILE_ATTRIBUTE_REPARSE_POINT
+// is set in FileAttributes, the field holds the reparse tag instead of the
+// extended-attribute size. This is the same union FindFirstFile exposes as
+// WIN32_FIND_DATA.dwReserved0.
+func (c FileIdBothDirectoryInformationDecoder) ReparsePointTag() uint32 {
+	if c.FileAttributes()&FILE_ATTRIBUTE_REPARSE_POINT == 0 {
+		return 0
+	}
+	return c.EaSize()
+}
+
 func (c FileIdBothDirectoryInformationDecoder) ShortNameLength() uint8 {
 	return c[68]
 }

--- a/internal/smb2/fscc.go
+++ b/internal/smb2/fscc.go
@@ -350,9 +350,9 @@ func (c FileDirectoryInformationDecoder) FileName(mc utf16le.MapChars) string {
 }
 
 // FileIdBothDirectoryInformationDecoder decodes a FILE_ID_BOTH_DIR_INFORMATION
-// entry (MS-FSCC 2.4.17). Its first 64 bytes are laid out identically to
-// FILE_DIRECTORY_INFORMATION; the trailing fields add the short name and the
-// server's 64-bit file reference number.
+// entry (MS-FSCC 2.4.22, FileIdBothDirectoryInformation). Its first 64 bytes
+// are laid out identically to FILE_DIRECTORY_INFORMATION; the trailing fields
+// add the short name and the server's 64-bit file reference number.
 type FileIdBothDirectoryInformationDecoder []byte
 
 func (c FileIdBothDirectoryInformationDecoder) IsInvalid() bool {
@@ -411,10 +411,10 @@ func (c FileIdBothDirectoryInformationDecoder) EaSize() uint32 {
 // ReparsePointTag is the reparse tag (IO_REPARSE_TAG_*) of the entry, or 0 when
 // it is not a reparse point.
 //
-// MS-FSCC 2.4.17 overloads the EaSize field: when FILE_ATTRIBUTE_REPARSE_POINT
-// is set in FileAttributes, the field holds the reparse tag instead of the
-// extended-attribute size. This is the same union FindFirstFile exposes as
-// WIN32_FIND_DATA.dwReserved0.
+// MS-FSCC 2.4.22 overloads the EaSize field: when FILE_ATTRIBUTE_REPARSE_POINT
+// is set in FileAttributes, the field holds a reparse tag (MS-FSCC 2.1.2.1)
+// instead of the extended-attribute size. This is the same union FindFirstFile
+// exposes as WIN32_FIND_DATA.dwReserved0.
 func (c FileIdBothDirectoryInformationDecoder) ReparsePointTag() uint32 {
 	if c.FileAttributes()&FILE_ATTRIBUTE_REPARSE_POINT == 0 {
 		return 0

--- a/internal/smb2/fscc_test.go
+++ b/internal/smb2/fscc_test.go
@@ -45,6 +45,43 @@ func TestFileIdBothDirectoryInformationDecoder(t *testing.T) {
 	require.EqualValues(0x20, c.FileAttributes())
 }
 
+// MS-FSCC 2.4.17 overloads EaSize as the reparse tag, but only when the
+// reparse attribute is set. Both readings must be decoded from the same bytes
+// without one bleeding into the other.
+func TestFileIdBothDirectoryInformationDecoderReparsePointTag(t *testing.T) {
+	const eaSizeOffset = 64
+
+	tests := []struct {
+		name       string
+		attributes uint32
+		field      uint32
+		wantTag    uint32
+	}{
+		{"symlink", FILE_ATTRIBUTE_REPARSE_POINT, IO_REPARSE_TAG_SYMLINK, IO_REPARSE_TAG_SYMLINK},
+		{"junction", FILE_ATTRIBUTE_REPARSE_POINT, IO_REPARSE_TAG_MOUNT_POINT, IO_REPARSE_TAG_MOUNT_POINT},
+		{"hsm", FILE_ATTRIBUTE_REPARSE_POINT, IO_REPARSE_TAG_HSM, IO_REPARSE_TAG_HSM},
+		// Without the attribute the field is a genuine EA size, not a tag.
+		{"plain file with EAs", FILE_ATTRIBUTE_NORMAL, 128, 0},
+		{"plain file", FILE_ATTRIBUTE_NORMAL, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			b := buildIdBothDirInfo(1, "entry")
+			le.PutUint32(b[56:60], tt.attributes)
+			le.PutUint32(b[eaSizeOffset:eaSizeOffset+4], tt.field)
+
+			c := FileIdBothDirectoryInformationDecoder(b)
+
+			require.False(c.IsInvalid())
+			require.Equal(tt.wantTag, c.ReparsePointTag())
+			require.Equal(tt.field, c.EaSize(), "EaSize must still report the raw field")
+		})
+	}
+}
+
 // A truncated entry must be rejected rather than panicking, since the buffer
 // comes straight off the wire.
 func TestFileIdBothDirectoryInformationDecoderIsInvalid(t *testing.T) {

--- a/internal/smb2/fscc_test.go
+++ b/internal/smb2/fscc_test.go
@@ -47,39 +47,24 @@ func TestFileIdBothDirectoryInformationDecoder(t *testing.T) {
 
 // MS-FSCC 2.4.22 overloads EaSize as the reparse tag, but only when the
 // reparse attribute is set. Both readings must be decoded from the same bytes
-// without one bleeding into the other.
+// without one bleeding into the other. The tag value itself is never
+// interpreted, so one tag exercises the whole path.
 func TestFileIdBothDirectoryInformationDecoderReparsePointTag(t *testing.T) {
-	const eaSizeOffset = 64
+	require := require.New(t)
 
-	tests := []struct {
-		name       string
-		attributes uint32
-		field      uint32
-		wantTag    uint32
-	}{
-		{"symlink", FILE_ATTRIBUTE_REPARSE_POINT, IO_REPARSE_TAG_SYMLINK, IO_REPARSE_TAG_SYMLINK},
-		{"junction", FILE_ATTRIBUTE_REPARSE_POINT, IO_REPARSE_TAG_MOUNT_POINT, IO_REPARSE_TAG_MOUNT_POINT},
-		{"hsm", FILE_ATTRIBUTE_REPARSE_POINT, IO_REPARSE_TAG_HSM, IO_REPARSE_TAG_HSM},
-		// Without the attribute the field is a genuine EA size, not a tag.
-		{"plain file with EAs", FILE_ATTRIBUTE_NORMAL, 128, 0},
-		{"plain file", FILE_ATTRIBUTE_NORMAL, 0, 0},
-	}
+	b := buildIdBothDirInfo(1, "entry")
+	c := FileIdBothDirectoryInformationDecoder(b)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require := require.New(t)
+	le.PutUint32(b[56:60], FILE_ATTRIBUTE_REPARSE_POINT)
+	le.PutUint32(b[64:68], IO_REPARSE_TAG_SYMLINK)
+	require.EqualValues(IO_REPARSE_TAG_SYMLINK, c.ReparsePointTag())
+	require.EqualValues(IO_REPARSE_TAG_SYMLINK, c.EaSize(), "EaSize must still report the raw field")
 
-			b := buildIdBothDirInfo(1, "entry")
-			le.PutUint32(b[56:60], tt.attributes)
-			le.PutUint32(b[eaSizeOffset:eaSizeOffset+4], tt.field)
-
-			c := FileIdBothDirectoryInformationDecoder(b)
-
-			require.False(c.IsInvalid())
-			require.Equal(tt.wantTag, c.ReparsePointTag())
-			require.Equal(tt.field, c.EaSize(), "EaSize must still report the raw field")
-		})
-	}
+	// Without the attribute the same field is a genuine EA size, not a tag.
+	le.PutUint32(b[56:60], FILE_ATTRIBUTE_NORMAL)
+	le.PutUint32(b[64:68], 128)
+	require.Zero(c.ReparsePointTag())
+	require.EqualValues(128, c.EaSize())
 }
 
 // A truncated entry must be rejected rather than panicking, since the buffer

--- a/internal/smb2/fscc_test.go
+++ b/internal/smb2/fscc_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // buildIdBothDirInfo encodes a FILE_ID_BOTH_DIR_INFORMATION entry (MS-FSCC
-// 2.4.17) with the given file id and name, so the decoder's offsets can be
+// 2.4.22) with the given file id and name, so the decoder's offsets can be
 // checked against an independently laid-out buffer.
 func buildIdBothDirInfo(fileID uint64, name string) []byte {
 	nameBytes := utf16le.Encode(name, utf16le.MapCharsNone)
@@ -45,7 +45,7 @@ func TestFileIdBothDirectoryInformationDecoder(t *testing.T) {
 	require.EqualValues(0x20, c.FileAttributes())
 }
 
-// MS-FSCC 2.4.17 overloads EaSize as the reparse tag, but only when the
+// MS-FSCC 2.4.22 overloads EaSize as the reparse tag, but only when the
 // reparse attribute is set. Both readings must be decoded from the same bytes
 // without one bleeding into the other.
 func TestFileIdBothDirectoryInformationDecoderReparsePointTag(t *testing.T) {

--- a/logoff_test.go
+++ b/logoff_test.go
@@ -1,0 +1,139 @@
+package smb2
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cloudsoda/go-smb2/internal/smb2"
+	"github.com/stretchr/testify/require"
+)
+
+// deadTransport models a socket that is up enough to be read from but whose
+// writes fail: the LOGOFF round trip cannot complete. It records Close calls so
+// a test can assert teardown released it.
+type deadTransport struct {
+	m         sync.Mutex
+	closes    int
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func newDeadTransport() *deadTransport {
+	return &deadTransport{closed: make(chan struct{})}
+}
+
+func (t *deadTransport) Write(p []byte) (int, error) {
+	return 0, errors.New("dead transport")
+}
+
+// ReadSize blocks until the transport is closed, the way a real socket with a
+// silent peer does, so the receiver goroutine stays alive until teardown.
+func (t *deadTransport) ReadSize() (int, error) {
+	<-t.closed
+	return 0, net.ErrClosed
+}
+
+func (t *deadTransport) Read(p []byte) (int, error) {
+	<-t.closed
+	return 0, net.ErrClosed
+}
+
+func (t *deadTransport) Close() error {
+	t.m.Lock()
+	t.closes++
+	t.m.Unlock()
+
+	t.closeOnce.Do(func() { close(t.closed) })
+
+	return nil
+}
+
+func (t *deadTransport) closeCount() int {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	return t.closes
+}
+
+// newTestConn wires a conn to an arbitrary transport with negotiated
+// parameters matching a typical SMB 3.0.2 connection, and starts its
+// sender/receiver goroutines.
+func newTestConn(t transport) *conn {
+	c := &conn{
+		t:                   t,
+		outstandingRequests: newOutstandingRequests(),
+		account:             openAccount(128),
+		rdone:               make(chan struct{}, 1),
+		wdone:               make(chan struct{}, 1),
+		write:               make(chan []byte, 1),
+		werr:                make(chan error, 1),
+		dialect:             smb2.SMB302,
+		maxReadSize:         bufSize,
+		maxWriteSize:        bufSize,
+		maxTransactSize:     bufSize,
+		capabilities:        smb2.SMB2_GLOBAL_CAP_LARGE_MTU,
+	}
+
+	go c.runSender()
+	go c.runReceiver()
+
+	return c
+}
+
+// TestLogoffClosesTransportOnFailure pins the contract that logoff releases the
+// connection even when the LOGOFF round trip errors. There is no other way to
+// release the socket and the sender/receiver goroutines, so returning early
+// would leak them for the life of the process — precisely on the path a caller
+// discarding a broken session takes.
+func TestLogoffClosesTransportOnFailure(t *testing.T) {
+	require := require.New(t)
+
+	dt := newDeadTransport()
+	c := newTestConn(dt)
+	s := &session{conn: c}
+
+	err := s.logoff(context.Background())
+	require.Error(err, "the round trip cannot succeed over a dead transport")
+	require.Equal(1, dt.closeCount(), "transport must be closed despite the failed round trip")
+
+	// The receiver observed the close and shut the connection down, which in
+	// turn releases the sender.
+	require.Eventually(func() bool {
+		select {
+		case <-c.wdone:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond, "receiver goroutine did not shut down")
+}
+
+// A second logoff on an already-torn-down connection must not block: the
+// receiver is gone, so nothing will drain a second rdone signal.
+func TestLogoffTwiceDoesNotBlock(t *testing.T) {
+	require := require.New(t)
+
+	dt := newDeadTransport()
+	c := newTestConn(dt)
+	s := &session{conn: c}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 3 {
+			_ = s.logoff(context.Background())
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("repeated logoff blocked")
+	}
+
+	require.Equal(3, dt.closeCount())
+}

--- a/readdirplus_test.go
+++ b/readdirplus_test.go
@@ -1,0 +1,96 @@
+package smb2
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/cloudsoda/go-smb2/internal/smb2"
+	"github.com/stretchr/testify/require"
+)
+
+// newBatchFailingDir builds a directory File whose listing is already resolved
+// (so Readdir performs no I/O) but whose tree conn cannot serve a compound
+// security batch: the credit account holds fewer than the 3 credits one file's
+// CREATE+QUERY_INFO+CLOSE triplet costs, so compoundSecurityInfoBatch fails
+// before touching the wire.
+func newBatchFailingDir(names []string) *File {
+	c := &conn{account: openAccount(1)}
+	s := &session{conn: c}
+	tc := &treeConn{session: s}
+
+	dirents := make([]os.FileInfo, len(names))
+	for i, name := range names {
+		dirents[i] = &FileStat{FileName: name}
+	}
+
+	return &File{
+		fs:          &Share{treeConn: tc, ctx: context.Background()},
+		fd:          &smb2.FileId{},
+		name:        "testdir",
+		dirents:     dirents,
+		noMoreFiles: true,
+	}
+}
+
+// TestReaddirPlusBatchFailureErrorShape pins the contract that a failed
+// compound security batch is reported only on the per-entry Err, never folded
+// into the returned error. The returned error describes the directory listing
+// alone, so a caller can degrade per entry instead of abandoning a directory
+// whose listing succeeded.
+func TestReaddirPlusBatchFailureErrorShape(t *testing.T) {
+	require := require.New(t)
+
+	names := []string{"alpha.txt", "bravo.txt", "charlie.txt"}
+	d := newBatchFailingDir(names)
+
+	entries, err := d.ReaddirPlus(-1, 0)
+	require.NoError(err, "listing succeeded, so the batch failure must not surface here")
+	require.Len(entries, len(names))
+
+	var secErr error
+	for i, e := range entries {
+		require.Equal(names[i], e.Name())
+		require.Error(e.Err, "entry %s: batch failure must be stamped on the entry", e.Name())
+		if secErr == nil {
+			secErr = e.Err
+		}
+		require.Equal(secErr, e.Err, "every entry carries the same batch error")
+		require.Nil(e.RawSecurityDescriptor, "no per-entry bytes exist when the batch failed")
+		require.Nil(e.SecurityDescriptor)
+	}
+
+	// The read loop still terminates: the drained handle reports io.EOF rather
+	// than a joined error that no longer compares equal to it.
+	entries, err = d.ReaddirPlus(1, 0)
+	require.Equal(io.EOF, err)
+	require.Empty(entries)
+}
+
+// TestReaddirPlusBatchFailureIncremental exercises the same contract through an
+// incremental read loop, the shape a caller actually uses.
+func TestReaddirPlusBatchFailureIncremental(t *testing.T) {
+	require := require.New(t)
+
+	names := []string{"alpha.txt", "bravo.txt", "charlie.txt", "delta.txt", "echo.txt"}
+	d := newBatchFailingDir(names)
+
+	var all []DirEntryPlus
+	for {
+		entries, err := d.ReaddirPlus(2, 0)
+		all = append(all, entries...)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(err, "a batch failure must never terminate the listing loop")
+		require.NotEmpty(entries)
+	}
+
+	require.Len(all, len(names))
+	for i, e := range all {
+		require.Equal(names[i], e.Name())
+		require.Error(e.Err)
+		require.Nil(e.RawSecurityDescriptor)
+	}
+}

--- a/session.go
+++ b/session.go
@@ -276,19 +276,26 @@ type session struct {
 }
 
 func (s *session) logoff(ctx context.Context) error {
+	// Release the transport and the receiver goroutine however the round trip
+	// turns out.
+	defer func() {
+		// rdone tells the receiver its impending read error is expected.
+		// non-blocking send
+		select {
+		case s.conn.rdone <- struct{}{}:
+		default:
+		}
+
+		s.conn.t.Close()
+	}()
+
 	req := new(smb2.LogoffRequest)
 
 	req.CreditCharge = 1
 
 	_, err := s.sendRecv(ctx, smb2.SMB2_LOGOFF, req)
-	if err != nil {
-		return err
-	}
 
-	s.conn.rdone <- struct{}{}
-	s.conn.t.Close()
-
-	return nil
+	return err
 }
 
 func (s *session) echo(ctx context.Context) error {

--- a/session.go
+++ b/session.go
@@ -279,8 +279,8 @@ func (s *session) logoff(ctx context.Context) error {
 	// Release the transport and the receiver goroutine however the round trip
 	// turns out.
 	defer func() {
-		// rdone tells the receiver its impending read error is expected.
-		// non-blocking send
+		// rdone tells the receiver its impending read error is expected. The
+		// send is non-blocking to defend against multiple calls to logoff().
 		select {
 		case s.conn.rdone <- struct{}{}:
 		default:

--- a/smb2_test.go
+++ b/smb2_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cloudsoda/go-smb2"
+	"github.com/cloudsoda/sddl"
 	"github.com/stretchr/testify/require"
 )
 
@@ -943,6 +944,78 @@ func TestSecurityDescriptor(t *testing.T) {
 	}
 }
 
+// ioReparseTagSymlink mirrors IO_REPARSE_TAG_SYMLINK. It is redeclared here
+// because internal/smb2 cannot be imported under the name this package already
+// binds to the public one.
+const ioReparseTagSymlink = uint32(0xA000000C)
+
+// TestReaddirReparsePointTag covers change 4: a directory listing distinguishes
+// a symlink from a plain file by reparse tag, not just by the shared
+// FILE_ATTRIBUTE_REPARSE_POINT bit.
+//
+// It does not cover junctions (IO_REPARSE_TAG_MOUNT_POINT): the library exposes
+// no way to create one, so that tag is only covered at the decoder level in
+// internal/smb2.
+func TestReaddirReparsePointTag(t *testing.T) {
+	if fs == nil {
+		t.Skip()
+	}
+
+	testDir := fmt.Sprintf("testDir-%d-TestReaddirReparsePointTag", os.Getpid())
+	require.NoError(t, fs.Mkdir(testDir, 0755))
+	defer func() {
+		_ = fs.RemoveAll(testDir)
+	}()
+
+	f, err := fs.Create(testDir + `\plainFile`)
+	require.NoError(t, err)
+	f.Close()
+
+	if err := fs.Symlink(testDir+`\plainFile`, testDir+`\linkToPlainFile`); err != nil {
+		t.Skip("server doesn't support reparse point:", err)
+	}
+
+	d, err := fs.Open(testDir)
+	require.NoError(t, err)
+	defer d.Close()
+
+	infos, err := d.Readdir(-1)
+	require.NoError(t, err)
+
+	tags := make(map[string]uint32, len(infos))
+	for _, info := range infos {
+		st, ok := info.Sys().(*smb2.FileStat)
+		require.True(t, ok, "entry %s: expected *smb2.FileStat", info.Name())
+		tags[info.Name()] = st.ReparsePointTag
+	}
+
+	require.Contains(t, tags, "plainFile")
+	require.Contains(t, tags, "linkToPlainFile")
+	require.Equal(t, uint32(0), tags["plainFile"], "a plain file carries no reparse tag")
+	require.Equal(t, ioReparseTagSymlink, tags["linkToPlainFile"])
+}
+
+// checkRawSecurityDescriptor asserts that the raw wire blob is present and is
+// the exact source of the parsed descriptor.
+//
+// It deliberately does not compare the raw bytes against
+// SecurityDescriptor.Binary(): that re-serialization panics on a NULL DACL
+// (SE_DACL_PRESENT with a nil DACL), which FromBinary legitimately produces,
+// and byte-faithful round-tripping is not a property callers rely on.
+func checkRawSecurityDescriptor(t *testing.T, e smb2.DirEntryPlus) {
+	t.Helper()
+
+	require := require.New(t)
+
+	require.NotEmpty(e.RawSecurityDescriptor, "entry %s: expected non-nil RawSecurityDescriptor", e.Name())
+	require.NotNil(e.SecurityDescriptor, "entry %s: expected non-nil SecurityDescriptor", e.Name())
+
+	reparsed, err := sddl.FromBinary(e.RawSecurityDescriptor)
+	require.NoError(err, "entry %s: reparsing RawSecurityDescriptor", e.Name())
+	require.Equal(e.SecurityDescriptor.String(), reparsed.String(),
+		"entry %s: raw bytes are not the source of the parsed descriptor", e.Name())
+}
+
 func TestReaddirPlus(t *testing.T) {
 	if fs == nil {
 		t.Skip()
@@ -996,6 +1069,7 @@ func TestReaddirPlus(t *testing.T) {
 			if e.SecurityDescriptor == nil {
 				t.Errorf("entry %s: expected non-nil SecurityDescriptor", e.Name())
 			}
+			checkRawSecurityDescriptor(t, e)
 			if e.IsDir() {
 				t.Errorf("entry %s: expected file, got directory", e.Name())
 			}
@@ -1043,6 +1117,7 @@ func TestReaddirPlus(t *testing.T) {
 			if e.SecurityDescriptor == nil {
 				t.Errorf("entry %s: expected non-nil SecurityDescriptor", e.Name())
 			}
+			checkRawSecurityDescriptor(t, e)
 		}
 	})
 
@@ -1072,6 +1147,7 @@ func TestReaddirPlus(t *testing.T) {
 			if entries[i].SecurityDescriptor == nil {
 				t.Errorf("entry %s: expected non-nil SecurityDescriptor", name)
 			}
+			checkRawSecurityDescriptor(t, entries[i])
 		}
 	})
 

--- a/smb2_test.go
+++ b/smb2_test.go
@@ -949,13 +949,13 @@ func TestSecurityDescriptor(t *testing.T) {
 // binds to the public one.
 const ioReparseTagSymlink = uint32(0xA000000C)
 
-// TestReaddirReparsePointTag covers change 4: a directory listing distinguishes
-// a symlink from a plain file by reparse tag, not just by the shared
+// TestReaddirReparsePointTag checks that a directory listing distinguishes a
+// symlink from a plain file by reparse tag, not just by the shared
 // FILE_ATTRIBUTE_REPARSE_POINT bit.
 //
-// It does not cover junctions (IO_REPARSE_TAG_MOUNT_POINT): the library exposes
-// no way to create one, so that tag is only covered at the decoder level in
-// internal/smb2.
+// Only symlinks are covered, because the library exposes no way to create a
+// junction. No tag-specific coverage is lost by that: the decoder returns the
+// field verbatim and never interprets the tag value.
 func TestReaddirReparsePointTag(t *testing.T) {
 	if fs == nil {
 		t.Skip()

--- a/smb2_test.go
+++ b/smb2_test.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/cloudsoda/go-smb2"
-	"github.com/cloudsoda/sddl"
 	"github.com/stretchr/testify/require"
 )
 
@@ -995,27 +994,6 @@ func TestReaddirReparsePointTag(t *testing.T) {
 	require.Equal(t, ioReparseTagSymlink, tags["linkToPlainFile"])
 }
 
-// checkRawSecurityDescriptor asserts that the raw wire blob is present and is
-// the exact source of the parsed descriptor.
-//
-// It deliberately does not compare the raw bytes against
-// SecurityDescriptor.Binary(): that re-serialization panics on a NULL DACL
-// (SE_DACL_PRESENT with a nil DACL), which FromBinary legitimately produces,
-// and byte-faithful round-tripping is not a property callers rely on.
-func checkRawSecurityDescriptor(t *testing.T, e smb2.DirEntryPlus) {
-	t.Helper()
-
-	require := require.New(t)
-
-	require.NotEmpty(e.RawSecurityDescriptor, "entry %s: expected non-nil RawSecurityDescriptor", e.Name())
-	require.NotNil(e.SecurityDescriptor, "entry %s: expected non-nil SecurityDescriptor", e.Name())
-
-	reparsed, err := sddl.FromBinary(e.RawSecurityDescriptor)
-	require.NoError(err, "entry %s: reparsing RawSecurityDescriptor", e.Name())
-	require.Equal(e.SecurityDescriptor.String(), reparsed.String(),
-		"entry %s: raw bytes are not the source of the parsed descriptor", e.Name())
-}
-
 func TestReaddirPlus(t *testing.T) {
 	if fs == nil {
 		t.Skip()
@@ -1069,7 +1047,6 @@ func TestReaddirPlus(t *testing.T) {
 			if e.SecurityDescriptor == nil {
 				t.Errorf("entry %s: expected non-nil SecurityDescriptor", e.Name())
 			}
-			checkRawSecurityDescriptor(t, e)
 			if e.IsDir() {
 				t.Errorf("entry %s: expected file, got directory", e.Name())
 			}
@@ -1117,7 +1094,6 @@ func TestReaddirPlus(t *testing.T) {
 			if e.SecurityDescriptor == nil {
 				t.Errorf("entry %s: expected non-nil SecurityDescriptor", e.Name())
 			}
-			checkRawSecurityDescriptor(t, e)
 		}
 	})
 
@@ -1147,7 +1123,6 @@ func TestReaddirPlus(t *testing.T) {
 			if entries[i].SecurityDescriptor == nil {
 				t.Errorf("entry %s: expected non-nil SecurityDescriptor", name)
 			}
-			checkRawSecurityDescriptor(t, entries[i])
 		}
 	})
 


### PR DESCRIPTION
Four changes batched for a single tag, driven by a Windows-first scanner backend that resolves owners, groups and ACLs through the host LSA.

1. DirEntryPlus.RawSecurityDescriptor

ReaddirPlus already had the wire bytes in hand (compoundSecurityResult.data) but discarded them after parsing into an *sddl.SecurityDescriptor. The SMB wire security descriptor is a self-relative SECURITY_DESCRIPTOR, byte-identical to what GetNamedSecurityInfo returns locally, so a caller that wants the native representation had to call SecurityDescriptor.Binary() to re-serialize back to the form the bytes started in — a parse-then-reserialize round trip per entry.

That round trip is a correctness bug, not merely overhead. sddl.Binary() has no error return and panics when the control word is inconsistent with the pointers: SE_DACL_PRESENT with a nil DACL, or SE_SACL_PRESENT with a nil SACL. FromBinary legitimately produces the first state, because a NULL DACL is encoded on the wire as SE_DACL_PRESENT with a DACL offset of 0 — the standard "everyone full access" descriptor. sddl exports no accessor for the control word, so a caller cannot detect the state beforehand, and a single such file in a share panics the walk mid-directory. Consuming the raw bytes removes the Binary() call and that panic class with it.

The bytes are retained even when sddl.FromBinary fails to parse, since that is precisely the case where a native-API caller may still succeed. The field is nil when the security query for the entry failed. SecurityDescriptor keeps its current meaning and population, so existing callers are unaffected.

2. ReaddirPlus reports batch security failures only per entry

When compoundSecurityInfoBatch failed, the old code stamped Err on every entry and also folded secErr into the top-level return via errors.Join. A caller could not distinguish "the listing died" from "the listing is fine, the security query failed, and every entry already records it", so it had to treat the whole directory as fatal and skip the subtree — even though every entry was listable and would have been usable with partial attributes.

The returned error now describes the directory listing alone: nil, io.EOF after the last entry, or a genuine Readdir failure. A security failure is reported exactly once, on each entry's Err. This also keeps the caller's read loop intact, because it no longer aborts on a non-nil return before reaching the drained handle that yields io.EOF.

Note for downstream projects: this is a behavior change. Code that detected a batch security failure through the top-level error must now check per-entry Err. Both paths already stamped Err identically, so per-entry consumers need no change.

The stale comment claiming the batch error was propagated "on the first entry" is corrected while here; the loop has always stamped every entry.

3. FileStat.ReparsePointTag

FileStat carried FileAttributes but no reparse tag, so a caller could not tell a symlink from a junction, dedup, HSM or cloud-placeholder file: all of them merely set FILE_ATTRIBUTE_REPARSE_POINT. The wire already delivers the tag. MS-FSCC 2.4.17 overloads the EaSize field of FILE_ID_BOTH_DIR_INFORMATION, which holds the reparse tag rather than the extended-attribute size when the reparse attribute is set — the same union FindFirstFile exposes as WIN32_FIND_DATA.dwReserved0.

The attribute check lives in the new decoder accessor FileIdBothDirectoryInformationDecoder.ReparsePointTag(), so the two readings of one field stay in one place; EaSize() still reports the raw field. FileStat gains the value from readdir(), which both Readdir and ReaddirPlus funnel through. File.Stat, Share.Stat and Share.Lstat continue to report 0, since FILE_ALL_INFORMATION and the CREATE response carry no reparse tag.

4. logoff closes the transport even when the round trip fails

session.logoff signalled rdone and closed the transport only after a successful LOGOFF. When sendRecv failed — a dead transport or an unresponsive server — the socket and the conn's sender and receiver goroutines were never released, and the library offers no other way to release them. That is exactly the path a caller discarding a broken session takes, so in a long-lived process the leak accumulated for the lifetime of the process.

Both steps now run from a defer, so teardown happens however the round trip turns out. The rdone send is non-blocking: rdone is a buffered channel of capacity one that the receiver drains once on exit, and closing unconditionally means the send can now occur when the receiver has already gone, where a blocking send on a full buffer would deadlock a repeated Logoff.

Tests

- TestReaddirPlus asserts RawSecurityDescriptor is non-nil on entries whose security query succeeded, and that sddl.FromBinary round-trips it to a descriptor equal to the parsed one. It deliberately does not compare against SecurityDescriptor.Binary(), which panics on the NULL-DACL descriptor described above.
- TestReaddirPlusBatchFailureErrorShape and TestReaddirPlusBatchFailureIncremental cover the new error shape offline, by pairing a pre-resolved listing with a credit account too small to fund one file's CREATE+QUERY_INFO+CLOSE triplet, so the batch fails before any I/O. They assert every entry carries the batch error and a nil RawSecurityDescriptor, that the returned error is the listing error, and that the read loop still terminates on io.EOF.
- TestFileIdBothDirectoryInformationDecoderReparsePointTag covers symlink, junction and HSM tags, and confirms that a plain file with extended attributes reports a tag of 0 while EaSize still reports the raw field.
- TestReaddirReparsePointTag checks the tag end to end over a live share. It does not cover junctions, because the library exposes no way to create one; that tag is covered at the decoder level only.
- TestLogoffClosesTransportOnFailure asserts the transport is closed and the receiver shuts down despite an errored round trip, and TestLogoffTwiceDoesNotBlock guards the non-blocking rdone send.